### PR TITLE
ansible: Use up to 50 forks

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 roles_path: ./roles/
 host_key_checking: False
+forks: 50


### PR DESCRIPTION
This speeds up deployment. Ansible will use this value or the number of
hosts - whichever is smaller.

Signed-off-by: Zack Cerza <zack@redhat.com>