### PR TITLE
ansible: Write grafana config when grafana is down

### DIFF
--- a/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -1,9 +1,44 @@
 ---
-- name: Start Grafana
+- name: Make sure grafana is down
+  service:
+    name: grafana-server
+    state: stopped
+
+- name: Wait for grafana to be stopped
+  wait_for:
+    port: 3000
+    state: stopped
+
+- set_fact:
+- name: Write grafana.ini
+  copy:
+    src: files/grafana.ini
+    dest: /etc/grafana/grafana.ini
+    owner: root
+    group: grafana
+    mode: 0640
+  tags: [ini]
+
+- name: Set domain in grafana.ini
+  lineinfile:
+    dest: /etc/grafana/grafana.ini
+    regexp: "^domain = .*"
+    insertafter: "^;domain = .*"
+    line: "domain = {{ ansible_fqdn }}"
+  tags: [ini]
+
+- include: grafana_plugins.yml
+  when: devel_mode
+
+- name: Enable and start grafana
   service:
     name: grafana-server
     state: started
     enabled: true
+
+- name: Wait for grafana to start
+  wait_for:
+    port: 3000
 
 - set_fact:
     grafana_data_source: >
@@ -51,28 +86,6 @@
     body: "{{ grafana_data_source }}"
     status_code: 200
   when: grafana_data_source_result is defined and grafana_data_source_result.status == 409
-
-- name: Write grafana.ini
-  copy:
-    src: files/grafana.ini
-    dest: /etc/grafana/grafana.ini
-    owner: root
-    group: grafana
-    mode: 0640
-  tags: [ini]
-  notify: Restart Grafana
-
-- name: Set domain in grafana.ini
-  lineinfile:
-    dest: /etc/grafana/grafana.ini
-    regexp: "^domain = .*"
-    insertafter: "^;domain = .*"
-    line: "domain = {{ ansible_fqdn }}"
-  tags: [ini]
-  notify: Restart Grafana
-
-- include: grafana_plugins.yml
-  when: devel_mode
 
 - name: Ship dashboard templates
   copy:

--- a/ansible/roles/ceph-grafana/tasks/grafana_plugins.yml
+++ b/ansible/roles/ceph-grafana/tasks/grafana_plugins.yml
@@ -26,4 +26,3 @@
 - name: Move Vonage Status Panel into place
   shell: "mv -f {{ vonage_plugin_path }}* {{ vonage_plugin_path }}"
   when: vonage_plugin.stat.exists is defined and not vonage_plugin.stat.exists
-  notify: Restart Grafana


### PR DESCRIPTION
We need to start and communcite with grafana after we push our own
config to the grafana. The old config can use different locations
e.g. for the DB and these won't get populated properly if we run
dashUpdater or post to the grafana API too early.

Signed-off-by: Boris Ranto <branto@redhat.com>

When you are doing a clean install (or remove /var/lib/grafana before deployment) then you will run into issues with the grafana restart order (it will be running with unmodified/old config for quite a while). This should fix it by ordering grafana stops/starts properly.