### PR TITLE
ansible: Replace dashboards by default when updating

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -2,6 +2,7 @@
 containerized_deployment: false
 use_epel: false
 devel_mode: true
+replace_dashboards: true
 graphite:
   port: "{{ graphite_port | default('8080') }}"
   user: admin

--- a/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -103,10 +103,18 @@
     src: dashboard.yml
     dest: /tmp/dashboard.yml
 
-- name: Push dashboards to Grafana
-  command: python /tmp/dashUpdater.py -c /tmp/dashboard.yml -D /tmp/dashboards
+- set_fact:
+    dashupdate_cmd: "python /tmp/dashUpdater.py"
+    dashboard_dir: "/tmp/dashboards"
   when: devel_mode
 
-- name: Push dashboards to Grafana
-  command: /usr/libexec/cephmetrics/dashUpdater.py -c /tmp/dashboard.yml -D /usr/share/cephmetrics/dashboards
+- set_fact:
+    dashupdate_cmd: "/usr/libexec/cephmetrics/dashUpdater.py"
+    dashboard_dir: "/usr/share/cephmetrics/dashboards"
   when: not devel_mode
+
+- set_fact:
+    dashupdate_mode: "{{ 'refresh' if replace_dashboards else 'update' }}"
+
+- name: Push dashboards to Grafana
+  command: "{{ dashupdate_cmd }} -m {{ dashupdate_mode }} -c /tmp/dashboard.yml -D {{ dashboard_dir }}"


### PR DESCRIPTION
This behavior can be disabled by setting 'replace_dashboards' to False

Signed-off-by: Zack Cerza <zack@redhat.com>