### PR TITLE
selinux: Additional policy changes

### DIFF
--- a/selinux/cephmetrics.te
+++ b/selinux/cephmetrics.te
@@ -4,18 +4,19 @@ require {
 	type collectd_t;
 	type ceph_t;
 	type ceph_var_run_t;
+	type ceph_var_lib_t;
 	class unix_stream_socket connectto;
 	class dir read;
+	class file getattr;
 	class capability2 block_suspend;
 }
 
 #============= collectd_t ==============
 
-#!!!! The file '/run/ceph/ceph-mon.node1.asok' is mislabeled on your system.  
-#!!!! Fix with $ restorecon -R -v /run/ceph/ceph-mon.node1.asok
 #!!!! This avc can be allowed using the boolean 'daemons_enable_cluster_mode'
 allow collectd_t ceph_t:unix_stream_socket connectto;
 allow collectd_t ceph_var_run_t:dir read;
+allow collectd_t ceph_var_lib_t:file getattr;
 allow collectd_t self:capability2 block_suspend;
 allow collectd_t var_log_t:dir { add_name write };
 allow collectd_t var_log_t:file create;


### PR DESCRIPTION
This was required to access whoami files inside /var/lib/ceph/osd/
directory.

Signed-off-by: Boris Ranto <branto@redhat.com>