### PR TITLE
rpm: Make devel_mode: false default in the ansible rpms

### DIFF
--- a/cephmetrics.spec.in
+++ b/cephmetrics.spec.in
@@ -65,6 +65,9 @@ mv -f grafana-piechart-panel* cephmetrics-piechart
 %build
 make -f /usr/share/selinux/devel/Makefile cephmetrics.pp
 
+# Change the devel_mode defaults
+sed -i -e 's/devel_mode: true/devel_mode: false/' ansible/roles/*/defaults/main.yml
+
 
 %install
 # Install dashUpdater.py


### PR DESCRIPTION
Signed-off-by: Boris Ranto <branto@redhat.com>

This changes the default value for devel_mode in rpm packages during the build time.