### PR TITLE
Mention enabling rhel-7-server-optional-rpms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On the host machine on which you will run ansible-playbook, do the following ste
 ```
 sudo su -
 mkdir ~/cephmetrics
-subscription-manager repos --enable rhel-7-server-rhscon-2-installer-rpms
+subscription-manager repos --enable rhel-7-server-optional-rpms --enable rhel-7-server-rhscon-2-installer-rpms
 yum install cephmetrics-ansible
 curl -L -o /etc/yum.repos.d/cephmetrics.repo http://download.ceph.com/cephmetrics/rpm-master/el7/cephmetrics.repo
 ```


### PR DESCRIPTION
It's needed for pyserial, python-twisted-core and python-zope-interface,
which are dependencies of python-carbon

Fixes issue #56 