### PR TITLE
Support CentOS 7 in devel_mode

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -3,7 +3,7 @@
 This set of ansible roles, in combination with `playbook.yml`, provide a way to deploy cephmetrics to monitor a Ceph cluster.
 
 ## Prerequisites
-- RHEL 7 is supported with `devel_mode` set to `True` or `False`. Ubuntu 16.04 is supported only when `devel_mode` is `True` at this point.
+- RHEL 7 is supported with `devel_mode` set to `True` or `False`. Ubuntu 16.04 and CentOS 7 are supported only when `devel_mode` is `True` at this point.
 - Currently only RHEL 7 is supported for all hosts
 - A functional [ceph](https://ceph.com/) cluster. [collectd](https://collectd.org/) will be used to collect metrics
 - A separate host to receive data pushed by hosts in the Ceph cluster, and run the dashboard to display that data.

--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -44,6 +44,8 @@ defaults:
       - graphite-web
       - python-carbon
       - grafana
+      # PyYAML is required by dashUpdater.py
+      - PyYAML
     apt:
       # unzip is needed to extract the Vonage plugin
       - unzip


### PR DESCRIPTION
Related to https://github.com/ceph/cephmetrics/issues/82

This provides `devel_mode` functionality for CentOS 7.