### PR TITLE
rpm: Drop collectors dependency for main package

### DIFF
--- a/cephmetrics.spec.in
+++ b/cephmetrics.spec.in
@@ -25,7 +25,6 @@ Requires(postun): policycoreutils
 Requires:	graphite-web
 Requires:	python-carbon
 Requires:       cephmetrics-grafana-plugins = %{version}-%{release}
-Requires:       cephmetrics-collectors = %{version}-%{release}
 
 %description
 The monitoring service with web frontend for Ceph storage clusters providing several statistical data graphed by grafana.


### PR DESCRIPTION
Signed-off-by: Boris Ranto <branto@redhat.com>

We do not really need this dependency and it can help separate the dependencies for the main server and the collectors running on the monitors.