### PR TITLE
Add iSCSI gateway support

### DIFF
--- a/ansible/roles/ceph-grafana/templates/dashboard.yml
+++ b/ansible/roles/ceph-grafana/templates/dashboard.yml
@@ -12,6 +12,7 @@ _dashboards:
   - ceph-rgw-workload
   - disk-busy-by-server
   - iops-by-server
+  - iscsi-overview
   - latency-by-server
   - network-usage-by-node
   - osd-node-detail

--- a/collectors/iscsi.py
+++ b/collectors/iscsi.py
@@ -105,8 +105,8 @@ class ISCSIGateway(BaseCollector):
     def refresh(self):
         """
         populate the instance by exploring rtslib
-        :return:
         """
+
         self.iops = 0
         self.read_bytes_per_sec = 0
         self.write_bytes_per_sec = 0
@@ -150,9 +150,9 @@ class ISCSIGateway(BaseCollector):
     def prune(self):
         """
         drop child objects held by the instance, that are no longer in the
-        iSCSI config i.e. don't report on old tut!
-        :return:
+        iSCSI config i.e. don't report on old information
         """
+
         for client_name in self.clients:
             client = self.clients[client_name]
 
@@ -189,43 +189,38 @@ class ISCSIGateway(BaseCollector):
                }
 
 
+
     def _get_so(self):
         return [so for so in self._root.storage_objects]
 
     def _get_node_acls(self):
         return [node for node in self._root.node_acls]
 
-    def _get_tpg_count(self):
+    @property
+    def tpg_count(self):
         return len([tpg for tpg in self._root.tpgs])
 
-    def _get_lun_count(self):
+    @property
+    def lun_count(self):
         return len(self._get_so())
 
-    def _get_session_count(self):
+    @property
+    def sessions(self):
         return len([session for session in self._root.sessions])
 
-    def _get_gateway_name(self):
+    @property
+    def gateway_name(self):
         # Only the 1st gateway is considered/supported
         gw_iqn = [gw.wwn for gw in self._root.targets][0]
         return gw_iqn.replace('.', '-')
 
-    def _get_client_count(self):
+    @property
+    def client_count(self):
         return len(self._get_node_acls())
 
-    def _get_capacity(self):
+    @property
+    def capacity(self):
         return sum([so.size for so in self._get_so()])
-
-    lun_count = property(_get_lun_count)
-
-    tpg_count = property(_get_tpg_count)
-
-    sessions = property(_get_session_count)
-
-    client_count = property(_get_client_count)
-
-    gateway_name = property(_get_gateway_name)
-
-    capacity = property(_get_capacity)
 
     def get_stats(self):
 

--- a/collectors/iscsi.py
+++ b/collectors/iscsi.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python2
+
+# requires python-rtslib_fb for LIO interaction
+
+import os
+import time
+from collectors.base import BaseCollector
+from rtslib_fb import RTSRoot
+from collectors.common import fread
+
+
+class Client(object):
+
+    def __init__(self, iqn):
+        self.iqn = iqn
+        self.name = iqn.replace('.', '-')
+        self.luns = {}
+        self.lun_count = 0
+        self._cycle = 0
+
+    def dump(self):
+        client_dump = {}
+        lun_info = {}
+        client_dump[self.name] = {"luns": {},
+                                  "lun_count": self.lun_count}
+        for lun_name in self.luns:
+            lun = self.luns[lun_name]
+            lun_info.update(lun.dump())
+
+        return {self.name: {"luns": lun_info,
+                            "lun_count": len(lun_info)}
+                }
+
+
+class LUN(object):
+
+    def __init__(self, client, tpg_lun):
+        self._path = tpg_lun.storage_object.path
+        self._tpg_lun = tpg_lun
+        self._name = tpg_lun.storage_object.name
+        self._display_name = tpg_lun.storage_object.name.replace('.', "-")
+        self._so = tpg_lun.storage_object
+        self._client = client
+        self._cycle = 0
+        self.size = 0
+        self.iops = 0
+        self.read_bytes_per_sec = 0
+        self.write_bytes_per_sec = 0
+        self.total_bytes_per_sec = 0
+        self.active_path = 0
+
+    def refresh(self, cycle_id):
+        self._cycle = cycle_id
+        self.size = self._so.size
+        stats_path = os.path.join(self._path, 'statistics/scsi_lu')
+        self.iops = int(fread(os.path.join(stats_path, "num_cmds")))
+        read_mb = float(fread(os.path.join(stats_path, "read_mbytes")))
+        write_mb = float(fread(os.path.join(stats_path, "write_mbytes")))
+        self.read_bytes_per_sec = int(read_mb * 1024 ** 2)
+        self.write_bytes_per_sec = int(write_mb * 1024 ** 2)
+        self.total_bytes_per_sec = self.read_bytes_per_sec + \
+                                   self.write_bytes_per_sec
+
+        if self._tpg_lun.alua_tg_pt_gp_name == 'ao':
+            self.active_path = 1
+        else:
+            self.active_path = 0
+
+    def dump(self):
+        return {self._display_name: {k: getattr(self, k) for k in self.__dict__
+                                     if not k.startswith("_")}}
+
+
+class ISCSIGateway(BaseCollector):
+    """
+    created on a host that has a /sys/kernel/config/target/iscsi dir
+    i.e. there is an iscsi gateway here!
+    """
+
+    metrics = {
+        "lun_count": ("lun_count", "gauge"),
+        "client_count": ("client_count", "gauge"),
+        "tpg_count": ("tpg_count", "gauge"),
+        "sessions": ("sessions", "gauge"),
+        "capacity": ("capacity", "gauge"),
+        "iops": ("iops", "derive"),
+        "read_bytes_per_sec": ("read_bytes_per_sec", "derive"),
+        "write_bytes_per_sec": ("write_bytes_per_sec", "derive"),
+        "total_bytes_per_sec": ("total_bytes_per_sec", "derive")
+    }
+
+    def __init__(self, *args, **kwargs):
+        BaseCollector.__init__(self, *args, **kwargs)
+
+        self._root = RTSRoot()
+
+        self.clients = {}
+        self.cycle = 0
+
+        self.iops = 0
+        self.read_bytes_per_sec = 0
+        self.write_bytes_per_sec = 0
+        self.total_bytes_per_sec = 0
+
+    def refresh(self):
+        """
+        populate the instance by exploring rtslib
+        :return:
+        """
+        self.iops = 0
+        self.read_bytes_per_sec = 0
+        self.write_bytes_per_sec = 0
+        self.total_bytes_per_sec = 0
+
+        if self.cycle == 10:
+            self.cycle = 0
+        else:
+            self.cycle += 1
+
+        for node_acl in self._root.node_acls:
+
+            client_name = node_acl.node_wwn
+
+            if client_name not in self.clients:
+                new_client = Client(client_name)
+                self.clients[client_name] = new_client
+
+            client = self.clients[client_name]
+            client.lun_count = 0
+            client._cycle = self.cycle
+
+            for lun in node_acl.mapped_luns:
+                client.lun_count += 1
+                tpg_lun = lun.tpg_lun
+                lun_name = tpg_lun.storage_object.name
+                if lun_name not in client.luns:
+                    lun = LUN(client, tpg_lun)
+                    client.luns[lun._name] = lun
+                else:
+                    lun = client.luns[lun_name]
+
+                lun.refresh(self.cycle)
+
+                self.iops += lun.iops
+                self.read_bytes_per_sec += lun.read_bytes_per_sec
+                self.write_bytes_per_sec += lun.write_bytes_per_sec
+                self.total_bytes_per_sec = self.read_bytes_per_sec + \
+                                           self.write_bytes_per_sec
+
+    def prune(self):
+        """
+        drop child objects held by the instance, that are no longer in the
+        iSCSI config i.e. don't report on old tut!
+        :return:
+        """
+        for client_name in self.clients:
+            client = self.clients[client_name]
+
+            for lun_name in client.luns:
+                lun = client.luns[lun_name]
+                if lun._cycle != self.cycle:
+                    # drop the lun entry
+                    self.logger.debug("pruning LUN '{}'".format(lun_name))
+
+                    del client.luns[lun_name]
+
+            if client._cycle != self.cycle:
+                # drop the client entry
+                self.logger.debug("pruning client '{}'".format(client_name))
+                del self.clients[client_name]
+
+    def dump(self):
+
+        gw_stats = {}
+        client_stats = {}
+
+        for metric in ISCSIGateway.metrics:
+            gw_stats[metric] = getattr(self, metric)
+
+        for client_name in self.clients:
+            client = self.clients[client_name]
+            client_stats.update(client.dump())
+
+        return {"iscsi": {
+                           "gw_name": {self.gateway_name: 0},
+                           "gw_stats": gw_stats,
+                           "gw_clients": client_stats
+                         }
+               }
+
+
+    def _get_so(self):
+        return [so for so in self._root.storage_objects]
+
+    def _get_node_acls(self):
+        return [node for node in self._root.node_acls]
+
+    def _get_tpg_count(self):
+        return len([tpg for tpg in self._root.tpgs])
+
+    def _get_lun_count(self):
+        return len(self._get_so())
+
+    def _get_session_count(self):
+        return len([session for session in self._root.sessions])
+
+    def _get_gateway_name(self):
+        # Only the 1st gateway is considered/supported
+        gw_iqn = [gw.wwn for gw in self._root.targets][0]
+        return gw_iqn.replace('.', '-')
+
+    def _get_client_count(self):
+        return len(self._get_node_acls())
+
+    def _get_capacity(self):
+        return sum([so.size for so in self._get_so()])
+
+    lun_count = property(_get_lun_count)
+
+    tpg_count = property(_get_tpg_count)
+
+    sessions = property(_get_session_count)
+
+    client_count = property(_get_client_count)
+
+    gateway_name = property(_get_gateway_name)
+
+    capacity = property(_get_capacity)
+
+    def get_stats(self):
+
+        start = time.time()
+
+        # populate gateway instance with the latest configuration from rtslib
+        self.refresh()
+
+        # Overtime they'll be churn in client and disks so we need to drop
+        # any entries from prior runs that are no longer seen in the iscsi
+        # configuration with the prune method
+        self.prune()
+
+        end = time.time()
+
+        self.logger.info("LIO stats took {}s".format(end - start))
+
+        return self.dump()
+

--- a/dashboard.yml
+++ b/dashboard.yml
@@ -26,6 +26,7 @@ _dashboards:
   - ceph-rgw-workload
   - disk-busy-by-server
   - iops-by-server
+  - iscsi-overview
   - latency-by-server
   - network-usage-by-node
   - osd-node-detail

--- a/dashboard.yml
+++ b/dashboard.yml
@@ -10,6 +10,10 @@ osd_servers:
 rgw_servers:
   - obj-rgw-1
 
+#iscsi_gateways:
+#  - rh7-gw1
+#  - rh7-gw2
+
 domain: storage.lab
 
 ###########################################################################

--- a/dashboards/current/iscsi-overview.json
+++ b/dashboards/current/iscsi-overview.json
@@ -1,0 +1,1877 @@
+{
+    "dashboard": {
+        "annotations": {
+            "list": []
+        }, 
+        "editable": false, 
+        "gnetId": null, 
+        "graphTooltip": 0, 
+        "hideControls": true, 
+        "id": 28, 
+        "links": [
+            {
+                "asDropdown": true, 
+                "icon": "external link", 
+                "tags": [
+                    "overview"
+                ], 
+                "title": "Shortcuts", 
+                "type": "dashboards"
+            }
+        ], 
+        "refresh": "10s", 
+        "rows": [
+            {
+                "collapse": false, 
+                "height": "200px", 
+                "panels": [
+                    {
+                        "content": "", 
+                        "height": "100", 
+                        "id": 19, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "mode": "markdown", 
+                        "span": 2, 
+                        "title": "", 
+                        "transparent": true, 
+                        "type": "text"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 1, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.tpg_count), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Gateways", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 2, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.client_count), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Clients", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "description": "Sessions shows the number of iSCSI clients currently logged in to the gateway group", 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 5, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "maxSeries(keepLastValue(consolidateBy(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.sessions, \"max\")))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Sessions", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "decimals": 0, 
+                        "description": "Capacity refers to the total capacity defined within the iSCSI gateway group, and available to iSCSI clients", 
+                        "format": "decbytes", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 4, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 2, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 2, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "hide": false, 
+                                "refId": "A", 
+                                "target": "maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.capacity), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Defined Capacity", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 3, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.lun_count), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "LUNs", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "100", 
+                        "id": 18, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "A", 
+                                "target": "maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.lun_count), \"max\"))", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "B", 
+                                "target": "countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "diffSeries(#A,#B)", 
+                                "targetFull": "diffSeries(maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.lun_count), \"max\")),countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\")))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Unused LUNs", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "content": "", 
+                        "height": "100", 
+                        "id": 22, 
+                        "links": [], 
+                        "minSpan": 3, 
+                        "mode": "markdown", 
+                        "span": 3, 
+                        "title": "", 
+                        "transparent": true, 
+                        "type": "text"
+                    }, 
+                    {
+                        "content": "", 
+                        "height": "100", 
+                        "id": 23, 
+                        "links": [], 
+                        "minSpan": 1, 
+                        "mode": "markdown", 
+                        "span": 1, 
+                        "title": "", 
+                        "transparent": true, 
+                        "type": "text"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "decimals": 0, 
+                        "description": "Total IOPS across all iSCSI gateways", 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "200", 
+                        "id": 6, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "", 
+                        "minSpan": 2, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 2, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": true
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "sumSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.iops), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "IOPS", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": null, 
+                        "decimals": 0, 
+                        "description": "Total read/write throughput across all iSCSI gateways", 
+                        "format": "decbytes", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "height": "200", 
+                        "id": 7, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "", 
+                        "minSpan": 2, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 2, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": true
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "sumSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.total_bytes_per_sec), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "title": "Throughput", 
+                        "type": "singlestat", 
+                        "valueFontSize": "70%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 1, 
+                        "height": "", 
+                        "id": 14, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 2, 
+                        "links": [], 
+                        "minSpan": 3, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 3, 
+                        "stack": true, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.interface.{bond,en,eth}*.if_octets.{tx,rx},1, \"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Network Load by Gateway", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "decbytes", 
+                                "label": "", 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "cacheTimeout": null, 
+                        "combine": {
+                            "label": "Others", 
+                            "threshold": 0
+                        }, 
+                        "datasource": null, 
+                        "fontSize": "80%", 
+                        "format": "short", 
+                        "height": "200", 
+                        "id": 26, 
+                        "interval": null, 
+                        "legend": {
+                            "show": true, 
+                            "values": true
+                        }, 
+                        "legendType": "Right side", 
+                        "links": [], 
+                        "maxDataPoints": 3, 
+                        "minSpan": 3, 
+                        "nullPointMode": "connected", 
+                        "pieType": "pie", 
+                        "span": 3, 
+                        "strokeWidth": 1, 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "A", 
+                                "target": "keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path)", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "B", 
+                                "target": "groupByNode(#A,1,\"sumSeries\")", 
+                                "targetFull": "groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path),1,\"sumSeries\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "title": "Primary LUN Paths Per Gateway", 
+                        "type": "grafana-piechart-panel", 
+                        "valueName": "current"
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "iSCSI Gateway Group : $gw_name", 
+                "titleSize": "h5"
+            }, 
+            {
+                "collapse": true, 
+                "height": 250, 
+                "panels": [
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "height": "", 
+                        "id": 21, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 2, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.iops,1, \"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "IOPS Load by Gateway", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "none", 
+                                "label": "IOPS", 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "height": "", 
+                        "id": 27, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 2, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.total_bytes_per_sec,1, \"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Throughput by Gateway", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "decbytes", 
+                                "label": "Throughput", 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "height": "", 
+                        "id": 12, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 2, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cpu.percent.{interrupt,steal,system,user,wait},1, \"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Gateway CPU Load", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "percent", 
+                                "label": "", 
+                                "logBase": 1, 
+                                "max": "100", 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "height": "", 
+                        "id": 24, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 2, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.memory.percent.used,1, \"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Gateway Memory Usage", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "percent", 
+                                "label": "", 
+                                "logBase": 1, 
+                                "max": "100", 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "Gateway Load", 
+                "titleSize": "h5"
+            }, 
+            {
+                "collapse": true, 
+                "height": 250, 
+                "panels": [
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "id": 8, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_clients.$clients.luns.*.iops,-4,\"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "IOPS by Client", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "none", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "id": 11, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_clients.$clients.luns.*.total_bytes_per_sec,-4,\"sum\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Throughput by Client", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "decbytes", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "id": 30, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "limit(groupByNode(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_clients.$clients.luns.*.iops,-2,\"sum\"),10)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "IOPS by RBD Image for Client '$clients'", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "none", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 0, 
+                        "id": 31, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "limit(groupByNode(collectd.*.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_clients.$clients.luns.*.total_bytes_per_sec,-2,\"sum\"),10)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Throughput by RBD Image for Client '$clients'", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "decbytes", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "Client Load : '$clients'", 
+                "titleSize": "h5"
+            }, 
+            {
+                "collapse": true, 
+                "height": 250, 
+                "panels": [
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "fontSize": "100%", 
+                        "id": 15, 
+                        "links": [], 
+                        "minSpan": 4, 
+                        "pageSize": 10, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": true
+                        }, 
+                        "span": 4, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Disk (pool-image)", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "Size", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "bytes"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size,-2,\"maxSeries\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "title": "RBD Images Masked to '$clients'", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "fontSize": "100%", 
+                        "id": 16, 
+                        "links": [], 
+                        "minSpan": 4, 
+                        "pageSize": 10, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": true
+                        }, 
+                        "span": 4, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Client", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "# Luns Masked", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 0, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "none"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "groupByNode(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.lun_count),-2,\"maxSeries\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "title": "Luns Per Client", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "fontSize": "100%", 
+                        "id": 17, 
+                        "links": [], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 4, 
+                        "pageSize": 10, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": true
+                        }, 
+                        "span": 4, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Client", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "hidden", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "Capacity", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "bytes"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "sumSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "title": "Client '$clients' - Masked Capacity", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "Client Configuration : '$clients'", 
+                "titleSize": "h5"
+            }
+        ], 
+        "schemaVersion": 14, 
+        "style": "dark", 
+        "tags": [], 
+        "templating": {
+            "list": [
+                {
+                    "allValue": null, 
+                    "current": {
+                        "selected": true, 
+                        "text": "test.lab", 
+                        "value": "test.lab"
+                    }, 
+                    "hide": 2, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "domain", 
+                    "options": [
+                        {
+                            "selected": true, 
+                            "text": "test.lab", 
+                            "value": "test.lab"
+                        }
+                    ], 
+                    "query": "test.lab", 
+                    "type": "custom"
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "text": "ceph", 
+                        "value": "ceph"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 0, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "cluster_name", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.*", 
+                    "refresh": 1, 
+                    "regex": "", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "tags": [], 
+                        "text": "All", 
+                        "value": "$__all"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 0, 
+                    "includeAll": true, 
+                    "label": "iSCSI Client", 
+                    "multi": false, 
+                    "name": "clients", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*", 
+                    "refresh": 1, 
+                    "regex": "", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "text": "iqn-2003-01-com-redhat-iscsi-gw_ceph-gw", 
+                        "value": "iqn-2003-01-com-redhat-iscsi-gw_ceph-gw"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 2, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "gw_name", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_name.*", 
+                    "refresh": 1, 
+                    "regex": "", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "text": "All", 
+                        "value": [
+                            "$__all"
+                        ]
+                    }, 
+                    "hide": 2, 
+                    "includeAll": true, 
+                    "label": null, 
+                    "multi": true, 
+                    "name": "iscsi_gateway", 
+                    "options": [
+                        {
+                            "selected": true, 
+                            "text": "All", 
+                            "value": "$__all"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "rh7-gw1", 
+                            "value": "rh7-gw1"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "rh7-gw2", 
+                            "value": "rh7-gw2"
+                        }
+                    ], 
+                    "query": "rh7-gw1, rh7-gw2", 
+                    "type": "custom"
+                }
+            ]
+        }, 
+        "time": {
+            "from": "now-1h", 
+            "to": "now"
+        }, 
+        "timepicker": {
+            "refresh_intervals": [
+                "5s", 
+                "10s", 
+                "30s", 
+                "1m", 
+                "5m", 
+                "15m", 
+                "30m", 
+                "1h", 
+                "2h", 
+                "1d"
+            ], 
+            "time_options": [
+                "5m", 
+                "15m", 
+                "1h", 
+                "6h", 
+                "12h", 
+                "24h", 
+                "2d", 
+                "7d", 
+                "30d"
+            ]
+        }, 
+        "timezone": "browser", 
+        "title": "iSCSI Overview", 
+        "version": 38
+    }, 
+    "meta": {
+        "canEdit": true, 
+        "canSave": true, 
+        "canStar": true, 
+        "created": "2017-08-03T23:35:37Z", 
+        "createdBy": "admin", 
+        "expires": "0001-01-01T00:00:00Z", 
+        "slug": "iscsi-overview", 
+        "type": "db", 
+        "updated": "2017-08-06T23:57:49Z", 
+        "updatedBy": "admin", 
+        "version": 38
+    }
+}

--- a/dashboards/current/iscsi-overview.json
+++ b/dashboards/current/iscsi-overview.json
@@ -487,13 +487,13 @@
                             {
                                 "hide": true, 
                                 "refId": "B", 
-                                "target": "countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
+                                "target": "countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateways.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
                                 "textEditor": true
                             }, 
                             {
                                 "refId": "C", 
                                 "target": "diffSeries(#A,#B)", 
-                                "targetFull": "diffSeries(maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.lun_count), \"max\")),countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\")))", 
+                                "targetFull": "diffSeries(maxSeries(consolidateBy(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_stats.lun_count), \"max\")),countSeries(groupByNode(keepLastValue(collectd.$iscsi_gateways.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\")))", 
                                 "textEditor": true
                             }
                         ], 
@@ -725,7 +725,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.interface.{bond,en,eth}*.if_octets.{tx,rx},1, \"sum\")", 
+                                "target": "groupByNode(collectd.$iscsi_gateways.$domain.interface.{bond,en,eth}*.if_octets.{tx,rx},1, \"sum\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -794,13 +794,13 @@
                             {
                                 "hide": true, 
                                 "refId": "A", 
-                                "target": "keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path)", 
+                                "target": "keepLastValue(collectd.$iscsi_gateways.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path)", 
                                 "textEditor": true
                             }, 
                             {
                                 "refId": "B", 
                                 "target": "groupByNode(#A,1,\"sumSeries\")", 
-                                "targetFull": "groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path),1,\"sumSeries\")", 
+                                "targetFull": "groupByNode(keepLastValue(collectd.$iscsi_gateways.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.*.luns.*.active_path),1,\"sumSeries\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -855,7 +855,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.iops,1, \"sum\")", 
+                                "target": "groupByNode(collectd.$iscsi_gateways.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.iops,1, \"sum\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -930,7 +930,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.total_bytes_per_sec,1, \"sum\")", 
+                                "target": "groupByNode(collectd.$iscsi_gateways.$domain.cephmetrics.derive.$cluster_name.iscsi.gw_stats.total_bytes_per_sec,1, \"sum\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -1005,7 +1005,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.cpu.percent.{interrupt,steal,system,user,wait},1, \"sum\")", 
+                                "target": "groupByNode(collectd.$iscsi_gateways.$domain.cpu.percent.{interrupt,steal,system,user,wait},1, \"sum\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -1080,7 +1080,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.$iscsi_gateway.$domain.memory.percent.used,1, \"sum\")", 
+                                "target": "groupByNode(collectd.$iscsi_gateways.$domain.memory.percent.used,1, \"sum\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -1514,7 +1514,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "groupByNode(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size,-2,\"maxSeries\")", 
+                                "target": "groupByNode(maximumAbove(collectd.*.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size,0),-2,\"maxSeries\")", 
                                 "textEditor": true
                             }
                         ], 
@@ -1679,7 +1679,7 @@
                         "targets": [
                             {
                                 "refId": "A", 
-                                "target": "sumSeries(groupByNode(keepLastValue(collectd.$iscsi_gateway.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
+                                "target": "sumSeries(groupByNode(keepLastValue(collectd.$iscsi_gateways.$domain.cephmetrics.gauge.$cluster_name.iscsi.gw_clients.$clients.luns.*.size),-2,\"maxSeries\"))", 
                                 "textEditor": true
                             }
                         ], 
@@ -1805,7 +1805,7 @@
                     "includeAll": true, 
                     "label": null, 
                     "multi": true, 
-                    "name": "iscsi_gateway", 
+                    "name": "iscsi_gateways", 
                     "options": [
                         {
                             "selected": true, 
@@ -1859,7 +1859,7 @@
         }, 
         "timezone": "browser", 
         "title": "iSCSI Overview", 
-        "version": 38
+        "version": 41
     }, 
     "meta": {
         "canEdit": true, 
@@ -1870,8 +1870,8 @@
         "expires": "0001-01-01T00:00:00Z", 
         "slug": "iscsi-overview", 
         "type": "db", 
-        "updated": "2017-08-06T23:57:49Z", 
+        "updated": "2017-08-07T23:20:49Z", 
         "updatedBy": "admin", 
-        "version": 38
+        "version": 41
     }
 }


### PR DESCRIPTION
This PR adds an iscsi overview dashboard, and an associated collector to gather performance and configuration metrics from LIO. At this stage the dashboard is not linked to from the at-a-glance dashboard.