### PR TITLE
ansible: Use graphite-web instead of graphite-api on Ubuntu

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -10,7 +10,7 @@ defaults:
     # change it via the web UI and then override this value to reflect.
     admin_password: admin
   graphite:
-    service: "{{ 'graphite-web' if ansible_pkg_mgr == 'yum' else 'graphite-api' }}"
+    service: graphite-web
     web_port: "{{ graphite_port | default('8080') }}"
     api_port: 8888
     user: admin
@@ -19,6 +19,18 @@ defaults:
     unix_user:
       yum: apache
       apt: _graphite
+    build_index:
+      yum: '/usr/bin/graphite-build-index'
+      apt: '/usr/bin/graphite-build-search-index'
+    apache_name:
+      yum: 'httpd'
+      apt: 'apache2'
+    apache_conf:
+      yum: '/etc/httpd/conf/httpd.conf'
+      apt: '/etc/apache2/apache2.conf'
+    site_conf:
+      yum: '/etc/httpd/conf.d/graphite-web.conf'
+      apt: '/etc/apache2/sites-available/graphite-web.conf'
   carbon:
     unix_user:
       yum: carbon
@@ -49,9 +61,9 @@ defaults:
     apt:
       # unzip is needed to extract the Vonage plugin
       - unzip
-      - graphite-api
-      # For graphite-api
-      - gunicorn3
+      - graphite-web
+      - apache2
+      - libapache2-mod-wsgi
       - graphite-carbon
       - grafana
       # for dashUpdater.py

--- a/ansible/roles/ceph-grafana/handlers/main.yml
+++ b/ansible/roles/ceph-grafana/handlers/main.yml
@@ -14,8 +14,8 @@
 
 - name: Restart graphite-web
   service:
-    # graphite-web is served by httpd
-    name: httpd
+    # graphite-web is served by apache
+    name: "{{ graphite.apache_name[ansible_pkg_mgr] }}"
     state: restarted
     enabled: true
   when:

--- a/ansible/roles/ceph-grafana/tasks/configure_graphite_web.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_graphite_web.yml
@@ -4,37 +4,57 @@
   become_user: "{{ graphite.unix_user[ansible_pkg_mgr] }}"
 
 - name: Build Graphite index
-  command: /usr/bin/graphite-build-index
+  command: "{{ graphite.build_index[ansible_pkg_mgr] }}"
   become_user: "{{ graphite.unix_user[ansible_pkg_mgr] }}"
 
-- name: Set or unset port in main httpd config
+- name: Set or unset port in main apache config
   lineinfile:
-    dest: /etc/httpd/conf/httpd.conf
+    dest: "/{{ graphite.apache_conf[ansible_pkg_mgr] }}"
     regexp: "^Listen .*"
     line: "Listen 80"
     insertafter: "^#Listen .*"
     state: "{{ 'present' if graphite.web_port == '80' else 'absent' }}"
   notify: Restart graphite-web
 
-- name: Set port in graphite httpd config
+# This is done automatically during package install on RPM-based distros
+- name: Copy graphite-web config on Ubuntu
+  copy:
+    src: /usr/share/graphite-web/apache2-graphite.conf
+    dest: "{{ graphite.site_conf[ansible_pkg_mgr] }}"
+    remote_src: yes
+    backup: yes
+  when: ansible_pkg_mgr == "apt"
+  notify: Restart graphite-web
+
+- name: Set port in graphite apache config
   lineinfile:
-    dest: /etc/httpd/conf.d/graphite-web.conf
+    dest: "{{ graphite.site_conf[ansible_pkg_mgr] }}"
     regexp: "^Listen .*"
     line: "Listen {{ graphite.web_port }}"
     insertbefore: "^<VirtualHost .*"
   notify: Restart graphite-web
 
-- name: Set VirtualHost port in graphite httpd config
+- name: Symlink graphite apache config on Ubuntu
+  file:
+    src: "{{ graphite.site_conf[ansible_pkg_mgr] }}"
+    dest: "/etc/apache2/sites-enabled/graphite-web.conf"
+    state: link
+    force: yes
+  when: ansible_pkg_mgr == "apt"
+  notify: Restart graphite-web
+
+- name: Set VirtualHost port in graphite apache config
   replace:
-    dest: /etc/httpd/conf.d/graphite-web.conf
+    dest: "{{ graphite.site_conf[ansible_pkg_mgr] }}"
     regexp: "^<VirtualHost \\*:.+>$"
     replace: "<VirtualHost *:{{ graphite.web_port }}>"
   notify: Restart graphite-web
 
 - name: Allow connecting to graphite without auth
   lineinfile:
-    dest: /etc/httpd/conf.d/graphite-web.conf
+    dest: "{{ graphite.site_conf[ansible_pkg_mgr] }}"
     line: "	Require all granted"
     insertafter: '<Directory "/usr/share/graphite/">'
     state: present
+  when: ansible_pkg_mgr == "yum"
   notify: Restart graphite-web

--- a/ansible/roles/ceph-grafana/tasks/start_services.yml
+++ b/ansible/roles/ceph-grafana/tasks/start_services.yml
@@ -6,6 +6,6 @@
     enabled: true
   with_items:
     - carbon-cache
-    # graphite-web is served by httpd
-    - "{{ 'httpd' if graphite.service == 'graphite-web' else graphite.service }}"
+    # graphite-web is served by apache
+    - "{{ graphite.apache_name[ansible_pkg_mgr] }}"
     - grafana-server


### PR DESCRIPTION
Because of https://github.com/brutasse/graphite-api/issues/222

Signed-off-by: David Galloway <dgallowa@redhat.com>