### PR TITLE
Set timezone in Graphite's config

### DIFF
--- a/ansible/roles/ceph-grafana/tasks/configure_graphite_web.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_graphite_web.yml
@@ -58,3 +58,16 @@
     state: present
   when: ansible_pkg_mgr == "yum"
   notify: Restart graphite-web
+
+- name: Get timezone
+  shell: "timedatectl | grep 'Time zone'"
+  register: timezone
+
+- name: Set timezone in local_settings.py
+  lineinfile:
+    dest: "{{ graphite.app_conf[ansible_pkg_mgr] }}"
+    line: "TIME_ZONE = '{{ timezone.stdout.strip().split(' ')[2] }}'"
+    regexp: "^TIME_ZONE = .*"
+    insertafter: '^#TIME_ZONE = .*'
+    state: present
+  notify: Restart graphite-web

--- a/ansible/roles/cephmetrics-common/defaults/main.yml
+++ b/ansible/roles/cephmetrics-common/defaults/main.yml
@@ -25,6 +25,9 @@ defaults:
     site_conf:
       yum: '/etc/httpd/conf.d/graphite-web.conf'
       apt: '/etc/apache2/sites-available/graphite-web.conf'
+    app_conf:
+      yum: '/etc/graphite-web/local_settings.py'
+      apt: '/etc/graphite/local_settings.py'
   carbon:
     unix_user:
       yum: carbon


### PR DESCRIPTION
Oddly, graphite defaults to using a hardcoded timezone rather than the
system's. This throws off queries, so let's configure it.

Signed-off-by: Zack Cerza <zack@redhat.com>