### PR TITLE
Mon._get_df_stats(): Sanitize pool names

### DIFF
--- a/collectors/mon.py
+++ b/collectors/mon.py
@@ -432,6 +432,8 @@ class Mon(BaseCollector):
     def _get_df_stats(self):
         """ get 'ceph df' stats from rados """
         raw_stats = self._mon_command('df')
+        for pool in raw_stats['pools']:
+            pool['name'] = pool['name'].replace('.', '_')
         return raw_stats
 
     def _get_pool_stats(self):


### PR DESCRIPTION
_get_pool_stats() already replaces '.' with '_'; let's copy that
behavior

Signed-off-by: Zack Cerza <zack@redhat.com>