### PR TITLE
selinux policy update

### DIFF
--- a/selinux/cephmetrics.te
+++ b/selinux/cephmetrics.te
@@ -1,25 +1,35 @@
-policy_module(cephmetrics, 1.0.0)
+policy_module(cephmetrics, 1.1.0)
 
 require {
+	type bin_t;
 	type collectd_t;
 	type ceph_t;
+	type ceph_exec_t;
 	type ceph_var_run_t;
 	type ceph_var_lib_t;
 	type fixed_disk_device_t;
+	type tmp_t;
 	class unix_stream_socket connectto;
 	class dir read;
 	class file getattr;
 	class capability2 block_suspend;
+	class lnk_file read;
+	class unix_stream_socket connectto;
+	class dir { read write };
+	class capability2 block_suspend;
+	class file { getattr execute execute_no_trans open read write };
 }
 
 #============= collectd_t ==============
 
+allow collectd_t bin_t:file { execute execute_no_trans };
 #!!!! This avc can be allowed using the boolean 'daemons_enable_cluster_mode'
 allow collectd_t ceph_t:unix_stream_socket connectto;
+allow collectd_t ceph_exec_t:file { execute execute_no_trans open read };
 allow collectd_t ceph_var_run_t:dir read;
-allow collectd_t ceph_var_lib_t:file getattr;
-allow collectd_t ceph_var_lib_t:lnk_file getattr;
-allow collectd_t ceph_var_lib_t:lnk_file read;
+allow collectd_t ceph_var_lib_t:dir read;
+allow collectd_t ceph_var_lib_t:file { getattr open read };
+allow collectd_t ceph_var_lib_t:lnk_file { getattr open read };
 allow collectd_t fixed_disk_device_t:blk_file getattr;
 allow collectd_t self:capability2 block_suspend;
 allow collectd_t var_log_t:dir { add_name write };


### PR DESCRIPTION
Policy update needed to account for the way the ceph environment
is detected when collectd starts up.