### PR TITLE
ansible: Remove references to old prod repo

### DIFF
--- a/ansible/roles/ceph-collectd/files/cephmetrics-prod.repo
+++ b/ansible/roles/ceph-collectd/files/cephmetrics-prod.repo
@@ -1,1 +1,0 @@
-../../../common/files/cephmetrics-prod.repo

--- a/ansible/roles/ceph-grafana/files/cephmetrics-prod.repo
+++ b/ansible/roles/ceph-grafana/files/cephmetrics-prod.repo
@@ -1,1 +1,0 @@
-../../../common/files/cephmetrics-prod.repo


### PR DESCRIPTION
This fixes the build failure after the patch that removed the original
repo file.

Signed-off-by: Boris Ranto <branto@redhat.com>