### PR TITLE
ansible: Do not enable rhsm repos

### DIFF
--- a/ansible/roles/ceph-grafana/tasks/setup_repos.yml
+++ b/ansible/roles/ceph-grafana/tasks/setup_repos.yml
@@ -68,12 +68,6 @@
     - ansible_pkg_mgr == 'apt'
     - devel_mode
 
-- name: Enable subscription-manager repos
-  command: "subscription-manager repos{% for repo in rhsm_repos %} --enable={{ repo }}{% endfor %}"
-  when:
-    - ansible_pkg_mgr == "yum"
-    - not devel_mode
-
 - name: Remove old cephmetrics production repo
   file:
     path: /etc/yum.repos.d/cephmetrics.repo

--- a/ansible/roles/cephmetrics-common/defaults/main.yml
+++ b/ansible/roles/cephmetrics-common/defaults/main.yml
@@ -42,10 +42,6 @@ defaults:
       - ['15m', '5y']
   # The firewalld zone that carbon and grafana will use
   firewalld_zone: public
-  # RHEL repos that need to be enabled with subscription-manager
-  rhsm_repos:
-    - rhel-7-server-rhscon-2-installer-rpms
-    - rhel-7-server-optional-rpms
   devel_packages:
     yum:
       # unzip is needed to extract the Vonage plugin


### PR DESCRIPTION
We are shipping as a regular product and as such, we cannot enable
additional repos via rhsm. The customers might even not have these repos
installed (especially the storage console repo might not be available to
them).

If we need any of the packages from these repos, we need to cross-ship
them in our product (as we already do downstream).

Signed-off-by: Boris Ranto <branto@redhat.com>