### PR TITLE
dashboard updates to address minor usability issues

### DIFF
--- a/dashboards/current/ceph-at-a-glance.json
+++ b/dashboards/current/ceph-at-a-glance.json
@@ -7,7 +7,7 @@
         "gnetId": null, 
         "graphTooltip": 0, 
         "hideControls": true, 
-        "id": 1, 
+        "id": 64, 
         "links": [
             {
                 "asDropdown": true, 
@@ -1057,7 +1057,16 @@
                         "hideTimeOverride": true, 
                         "id": 38, 
                         "interval": null, 
-                        "links": [], 
+                        "links": [
+                            {
+                                "dashUri": "db/ceph-cluster", 
+                                "dashboard": "Ceph Cluster", 
+                                "params": "panelId=3&fullscreen&orgId=1", 
+                                "targetBlank": true, 
+                                "title": "Cluster Capacity Information", 
+                                "type": "dashboard"
+                            }
+                        ], 
                         "mappingType": 1, 
                         "mappingTypes": [
                             {
@@ -2843,8 +2852,8 @@
                 {
                     "allValue": null, 
                     "current": {
-                        "text": "front.sepia.ceph.com", 
-                        "value": "front.sepia.ceph.com"
+                        "text": "storage.lab", 
+                        "value": "storage.lab"
                     }, 
                     "hide": 2, 
                     "includeAll": false, 
@@ -2854,11 +2863,11 @@
                     "options": [
                         {
                             "selected": true, 
-                            "text": "front.sepia.ceph.com", 
-                            "value": "front.sepia.ceph.com"
+                            "text": "storage.lab", 
+                            "value": "storage.lab"
                         }
                     ], 
-                    "query": "front.sepia.ceph.com", 
+                    "query": "storage.lab", 
                     "type": "custom"
                 }, 
                 {
@@ -2923,89 +2932,28 @@
                         }, 
                         {
                             "selected": false, 
-                            "text": "mira019", 
-                            "value": "mira019"
+                            "text": "obj-osd-1", 
+                            "value": "obj-osd-1"
                         }, 
                         {
                             "selected": false, 
-                            "text": "mira021", 
-                            "value": "mira021"
+                            "text": "obj-osd-2", 
+                            "value": "obj-osd-2"
                         }, 
                         {
                             "selected": false, 
-                            "text": "mira031", 
-                            "value": "mira031"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira049", 
-                            "value": "mira049"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira055", 
-                            "value": "mira055"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira060", 
-                            "value": "mira060"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira070", 
-                            "value": "mira070"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira076", 
-                            "value": "mira076"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira087", 
-                            "value": "mira087"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira093", 
-                            "value": "mira093"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira099", 
-                            "value": "mira099"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira116", 
-                            "value": "mira116"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira120", 
-                            "value": "mira120"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "mira122", 
-                            "value": "mira122"
-                        }, 
-                        {
-                            "selected": false, 
-                            "text": "apama002", 
-                            "value": "apama002"
+                            "text": "obj-osd-3", 
+                            "value": "obj-osd-3"
                         }
                     ], 
-                    "query": "mira019,mira021,mira031,mira049,mira055,mira060,mira070,mira076,mira087,mira093,mira099,mira116,mira120,mira122,apama002", 
+                    "query": "obj-osd-1,obj-osd-2,obj-osd-3", 
                     "type": "custom"
                 }, 
                 {
                     "allValue": null, 
                     "current": {
-                        "selected": true, 
-                        "text": "All", 
-                        "value": "$__all"
+                        "text": "obj-rgw-1", 
+                        "value": "obj-rgw-1"
                     }, 
                     "hide": 2, 
                     "includeAll": false, 
@@ -3015,11 +2963,11 @@
                     "options": [
                         {
                             "selected": true, 
-                            "text": "All", 
-                            "value": "$__all"
+                            "text": "obj-rgw-1", 
+                            "value": "obj-rgw-1"
                         }
                     ], 
-                    "query": "", 
+                    "query": "obj-rgw-1", 
                     "type": "custom"
                 }, 
                 {
@@ -3120,20 +3068,20 @@
         }, 
         "timezone": "browser", 
         "title": "Ceph - At A Glance", 
-        "version": 80
+        "version": 3
     }, 
     "meta": {
         "canEdit": true, 
         "canSave": true, 
         "canStar": true, 
-        "created": "2017-09-05T14:36:14-04:00", 
-        "createdBy": "admin", 
+        "created": "2017-10-06T01:14:08Z", 
+        "createdBy": "admin@localhost", 
         "expires": "0001-01-01T00:00:00Z", 
         "isStarred": true, 
         "slug": "ceph-at-a-glance", 
         "type": "db", 
-        "updated": "2017-09-12T15:16:24-04:00", 
-        "updatedBy": "admin", 
-        "version": 80
+        "updated": "2017-10-06T01:22:41Z", 
+        "updatedBy": "admin@localhost", 
+        "version": 3
     }
 }

--- a/dashboards/current/ceph-osd-information.json
+++ b/dashboards/current/ceph-osd-information.json
@@ -1,2172 +1,2178 @@
 {
-   "dashboard" : {
-      "timepicker" : {
-         "time_options" : [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d"
-         ],
-         "refresh_intervals" : [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ]
-      },
-      "tags" : [
-         "overview"
-      ],
-      "title" : "Ceph OSD Information",
-      "editable" : false,
-      "schemaVersion" : 14,
-      "templating" : {
-         "list" : [
+    "dashboard": {
+        "annotations": {
+            "list": []
+        }, 
+        "editable": false, 
+        "gnetId": null, 
+        "graphTooltip": 0, 
+        "hideControls": true, 
+        "id": 67, 
+        "links": [
             {
-               "options" : [
-                  {
-                     "text" : "test.lab",
-                     "selected" : true,
-                     "value" : "test.lab"
-                  }
-               ],
-               "query" : "test.lab",
-               "multi" : false,
-               "label" : null,
-               "type" : "custom",
-               "current" : {
-                  "selected" : true,
-                  "value" : "test.lab",
-                  "text" : "test.lab"
-               },
-               "name" : "domain",
-               "hide" : 2,
-               "allValue" : null,
-               "includeAll" : false
-            },
-            {
-               "refresh" : 1,
-               "regex" : "",
-               "sort" : 0,
-               "useTags" : false,
-               "options" : [],
-               "query" : "collectd.*.$domain.cephmetrics.gauge.*",
-               "includeAll" : false,
-               "name" : "cluster_name",
-               "allValue" : null,
-               "datasource" : "Local",
-               "label" : null,
-               "tagValuesQuery" : "",
-               "multi" : false,
-               "tagsQuery" : "",
-               "tags" : [],
-               "hide" : 2,
-               "type" : "query",
-               "current" : {
-                  "selected" : true,
-                  "value" : "ceph",
-                  "text" : "ceph"
-               }
-            },
-            {
-               "multi" : false,
-               "query" : "95,96,97,98,99",
-               "options" : [
-                  {
-                     "value" : "95",
-                     "selected" : true,
-                     "text" : "95"
-                  },
-                  {
-                     "value" : "96",
-                     "selected" : false,
-                     "text" : "96"
-                  },
-                  {
-                     "text" : "97",
-                     "value" : "97",
-                     "selected" : false
-                  },
-                  {
-                     "selected" : false,
-                     "value" : "98",
-                     "text" : "98"
-                  },
-                  {
-                     "value" : "99",
-                     "selected" : false,
-                     "text" : "99"
-                  }
-               ],
-               "label" : null,
-               "current" : {
-                  "value" : "95",
-                  "selected" : true,
-                  "text" : "95"
-               },
-               "type" : "custom",
-               "hide" : 0,
-               "allValue" : null,
-               "name" : "percentile",
-               "includeAll" : false
-            },
-            {
-               "name" : "max_devices",
-               "allValue" : null,
-               "hide" : 2,
-               "current" : {
-                  "text" : "10",
-                  "selected" : true,
-                  "value" : "10"
-               },
-               "type" : "custom",
-               "includeAll" : false,
-               "label" : null,
-               "multi" : false,
-               "query" : "10",
-               "options" : [
-                  {
-                     "selected" : true,
-                     "value" : "10",
-                     "text" : "10"
-                  }
-               ]
-            },
-            {
-               "name" : "osd_id",
-               "allValue" : null,
-               "includeAll" : true,
-               "sort" : 0,
-               "useTags" : false,
-               "query" : "collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*",
-               "options" : [],
-               "regex" : "/^\\d+$/",
-               "refresh" : 1,
-               "hide" : 0,
-               "current" : {
-                  "value" : "$__all",
-                  "text" : "All"
-               },
-               "type" : "query",
-               "tagsQuery" : "",
-               "tags" : [],
-               "label" : "OSD Id",
-               "tagValuesQuery" : "",
-               "multi" : false,
-               "datasource" : "Local"
-            },
-            {
-               "name" : "osd_id_hidden",
-               "allValue" : null,
-               "includeAll" : true,
-               "sort" : 0,
-               "useTags" : false,
-               "options" : [],
-               "query" : "collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*",
-               "refresh" : 1,
-               "regex" : "/^\\d+$/",
-               "hide" : 2,
-               "current" : {
-                  "value" : "$__all",
-                  "text" : "All"
-               },
-               "type" : "query",
-               "tagsQuery" : "",
-               "tags" : [],
-               "label" : "OSD Id",
-               "tagValuesQuery" : "",
-               "multi" : false,
-               "datasource" : "Local"
+                "asDropdown": true, 
+                "icon": "external link", 
+                "tags": [
+                    "overview"
+                ], 
+                "title": "Shortcuts", 
+                "type": "dashboards"
             }
-         ]
-      },
-      "hideControls" : true,
-      "style" : "dark",
-      "time" : {
-         "from" : "now-1h",
-         "to" : "now"
-      },
-      "id" : 26,
-      "graphTooltip" : 0,
-      "version" : 38,
-      "rows" : [
-         {
-            "title" : "OSD Summary",
-            "repeat" : null,
-            "repeatRowId" : null,
-            "collapse" : false,
-            "repeatIteration" : null,
-            "titleSize" : "h5",
-            "height" : "220px",
-            "showTitle" : true,
-            "panels" : [
-               {
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\"))",
-                        "textEditor" : true
-                     }
-                  ],
-                  "postfixFontSize" : "50%",
-                  "rangeMaps" : [
-                     {
-                        "text" : "N/A",
-                        "from" : "null",
-                        "to" : "null"
-                     }
-                  ],
-                  "mappingType" : 1,
-                  "gauge" : {
-                     "thresholdMarkers" : true,
-                     "minValue" : 0,
-                     "thresholdLabels" : false,
-                     "maxValue" : 100,
-                     "show" : false
-                  },
-                  "cacheTimeout" : null,
-                  "prefixFontSize" : "50%",
-                  "colorValue" : false,
-                  "links" : [],
-                  "span" : 1,
-                  "interval" : null,
-                  "nullPointMode" : "connected",
-                  "prefix" : "",
-                  "tableColumn" : "",
-                  "minSpan" : 1,
-                  "valueMaps" : [
-                     {
-                        "op" : "=",
-                        "value" : "null",
-                        "text" : "N/A"
-                     }
-                  ],
-                  "datasource" : "Local",
-                  "valueFontSize" : "80%",
-                  "maxDataPoints" : 100,
-                  "postfix" : "",
-                  "id" : 11,
-                  "sparkline" : {
-                     "lineColor" : "rgb(31, 120, 193)",
-                     "full" : false,
-                     "show" : false,
-                     "fillColor" : "rgba(31, 118, 189, 0.18)"
-                  },
-                  "nullText" : null,
-                  "title" : "OSDs",
-                  "valueName" : "avg",
-                  "mappingTypes" : [
-                     {
-                        "value" : 1,
-                        "name" : "value to text"
-                     },
-                     {
-                        "name" : "range to text",
-                        "value" : 2
-                     }
-                  ],
-                  "colors" : [
-                     "rgba(245, 54, 54, 0.9)",
-                     "rgba(237, 129, 40, 0.89)",
-                     "rgba(50, 172, 45, 0.97)"
-                  ],
-                  "type" : "singlestat",
-                  "format" : "none",
-                  "thresholds" : "",
-                  "colorBackground" : false
-               },
-               {
-                  "targets" : [
-                     {
-                        "target" : "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\"))",
-                        "refId" : "A",
-                        "textEditor" : true
-                     }
-                  ],
-                  "mappingType" : 1,
-                  "rangeMaps" : [
-                     {
-                        "to" : "null",
-                        "text" : "N/A",
-                        "from" : "null"
-                     }
-                  ],
-                  "postfixFontSize" : "50%",
-                  "interval" : null,
-                  "span" : 1,
-                  "links" : [],
-                  "cacheTimeout" : null,
-                  "gauge" : {
-                     "maxValue" : 100,
-                     "show" : false,
-                     "minValue" : 0,
-                     "thresholdMarkers" : true,
-                     "thresholdLabels" : false
-                  },
-                  "prefixFontSize" : "50%",
-                  "colorValue" : false,
-                  "tableColumn" : "",
-                  "nullPointMode" : "connected",
-                  "prefix" : "",
-                  "valueMaps" : [
-                     {
-                        "text" : "N/A",
-                        "value" : "null",
-                        "op" : "="
-                     }
-                  ],
-                  "minSpan" : 1,
-                  "postfix" : "",
-                  "datasource" : "Local",
-                  "valueFontSize" : "80%",
-                  "maxDataPoints" : 100,
-                  "id" : 12,
-                  "title" : "OSDs UP",
-                  "valueName" : "avg",
-                  "mappingTypes" : [
-                     {
-                        "value" : 1,
-                        "name" : "value to text"
-                     },
-                     {
-                        "value" : 2,
-                        "name" : "range to text"
-                     }
-                  ],
-                  "sparkline" : {
-                     "fillColor" : "rgba(31, 118, 189, 0.18)",
-                     "show" : false,
-                     "full" : false,
-                     "lineColor" : "rgb(31, 120, 193)"
-                  },
-                  "nullText" : null,
-                  "thresholds" : "",
-                  "colorBackground" : false,
-                  "colors" : [
-                     "rgba(245, 54, 54, 0.9)",
-                     "rgba(237, 129, 40, 0.89)",
-                     "rgba(50, 172, 45, 0.97)"
-                  ],
-                  "type" : "singlestat",
-                  "format" : "none"
-               },
-               {
-                  "postfixFontSize" : "50%",
-                  "targets" : [
-                     {
-                        "target" : "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\"))",
-                        "hide" : true,
-                        "refId" : "A",
-                        "textEditor" : true
-                     },
-                     {
-                        "target" : "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\"))",
-                        "hide" : true,
-                        "refId" : "B",
-                        "textEditor" : true
-                     },
-                     {
-                        "refId" : "C",
-                        "target" : "diffSeries(#B,#A)",
-                        "targetFull" : "diffSeries(keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\")),keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\")))",
-                        "textEditor" : true
-                     }
-                  ],
-                  "links" : [],
-                  "interval" : null,
-                  "prefixFontSize" : "50%",
-                  "gauge" : {
-                     "maxValue" : 100,
-                     "show" : false,
-                     "thresholdMarkers" : true,
-                     "minValue" : 0,
-                     "thresholdLabels" : false
-                  },
-                  "tableColumn" : "",
-                  "valueMaps" : [
-                     {
-                        "op" : "=",
-                        "value" : "null",
-                        "text" : "N/A"
-                     }
-                  ],
-                  "postfix" : "",
-                  "valueFontSize" : "80%",
-                  "datasource" : "Local",
-                  "id" : 16,
-                  "mappingTypes" : [
-                     {
-                        "name" : "value to text",
-                        "value" : 1
-                     },
-                     {
-                        "value" : 2,
-                        "name" : "range to text"
-                     }
-                  ],
-                  "title" : "OSDs DOWN",
-                  "valueName" : "current",
-                  "thresholds" : "1,3",
-                  "type" : "singlestat",
-                  "colors" : [
-                     "rgba(251,251,251,0.97)",
-                     "rgba(255,165,0, 1)",
-                     "rgba(245, 54, 54, 0.9)"
-                  ],
-                  "rangeMaps" : [
-                     {
-                        "from" : "null",
-                        "text" : "N/A",
-                        "to" : "null"
-                     }
-                  ],
-                  "mappingType" : 1,
-                  "decimals" : 0,
-                  "span" : 1,
-                  "colorValue" : false,
-                  "cacheTimeout" : null,
-                  "prefix" : "",
-                  "nullPointMode" : "connected",
-                  "minSpan" : 1,
-                  "maxDataPoints" : 100,
-                  "nullText" : null,
-                  "sparkline" : {
-                     "show" : false,
-                     "fillColor" : "rgba(31, 118, 189, 0.18)",
-                     "full" : false,
-                     "lineColor" : "rgb(31, 120, 193)"
-                  },
-                  "colorBackground" : true,
-                  "format" : "none"
-               },
-               {
-                  "interval" : null,
-                  "span" : 3,
-                  "combine" : {
-                     "threshold" : 0,
-                     "label" : "Others"
-                  },
-                  "links" : [],
-                  "legend" : {
-                     "show" : true,
-                     "percentage" : false,
-                     "values" : true,
-                     "sortDesc" : true
-                  },
-                  "cacheTimeout" : null,
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "target" : "currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0)",
-                        "hide" : true,
-                        "refId" : "A"
-                     },
-                     {
-                        "targetFull" : "alias(currentBelow(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),\"<1TB\")",
-                        "textEditor" : true,
-                        "hide" : true,
-                        "target" : "alias(currentBelow(#A,1099511627776),\"<1TB\")",
-                        "refId" : "B"
-                     },
-                     {
-                        "refId" : "C",
-                        "hide" : true,
-                        "target" : "alias(currentBelow(currentAbove(#A,1099511627776),2199023255552),\"2TB\")",
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),2199023255552),\"2TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),2199023255552),3298534883328),\"3TB\")",
-                        "refId" : "Q",
-                        "target" : "alias(currentBelow(currentAbove(#A,2199023255552),3298534883328),\"3TB\")",
-                        "hide" : true
-                     },
-                     {
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),3298534883328),4398046511104),\"4TB\")",
-                        "textEditor" : true,
-                        "refId" : "D",
-                        "hide" : true,
-                        "target" : "alias(currentBelow(currentAbove(#A,3298534883328),4398046511104),\"4TB\")"
-                     },
-                     {
-                        "target" : "alias(currentBelow(currentAbove(#A,4398046511104),6597069766656),\"6TB\")",
-                        "hide" : true,
-                        "refId" : "E",
-                        "textEditor" : true,
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),4398046511104),6597069766656),\"6TB\")"
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),6597069766656),8796093022208),\"8TB\")",
-                        "hide" : true,
-                        "target" : "alias(currentBelow(currentAbove(#A,6597069766656),8796093022208),\"8TB\")",
-                        "refId" : "F"
-                     },
-                     {
-                        "target" : "alias(currentBelow(currentAbove(#A,8796093022208),10995116277760),\"10TB\")",
-                        "hide" : true,
-                        "refId" : "G",
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),8796093022208),10995116277760),\"10TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "refId" : "H",
-                        "target" : "alias(currentBelow(currentAbove(#A,10995116277760),13194139533312),\"12TB\")",
-                        "hide" : true,
-                        "targetFull" : "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),10995116277760),13194139533312),\"12TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "target" : "alias(countSeries(#B), \"<1TB\")",
-                        "refId" : "I",
-                        "textEditor" : true,
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),\"<1TB\")), \"<1TB\")"
-                     },
-                     {
-                        "refId" : "J",
-                        "target" : "alias(countSeries(#C), \"2TB\")",
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),2199023255552),\"2TB\")), \"2TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),3298534883328),4398046511104),\"4TB\")), \"4TB\")",
-                        "textEditor" : true,
-                        "refId" : "K",
-                        "target" : "alias(countSeries(#D), \"4TB\")"
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),4398046511104),6597069766656),\"6TB\")), \"6TB\")",
-                        "target" : "alias(countSeries(#E), \"6TB\")",
-                        "refId" : "L"
-                     },
-                     {
-                        "refId" : "M",
-                        "target" : "alias(countSeries(#F), \"8TB\")",
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),6597069766656),8796093022208),\"8TB\")), \"8TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "target" : "alias(countSeries(#G), \"10TB\")",
-                        "refId" : "N",
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),8796093022208),10995116277760),\"10TB\")), \"10TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "refId" : "O",
-                        "target" : "alias(countSeries(#H), \"12TB\")",
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),10995116277760),13194139533312),\"12TB\")), \"12TB\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "targetFull" : "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),2199023255552),3298534883328),\"3TB\")), \"3TB\")",
-                        "textEditor" : true,
-                        "target" : "alias(countSeries(#Q), \"3TB\")",
-                        "refId" : "P"
-                     }
-                  ],
-                  "description" : "The pie chart shows the various disk sizes used within the cluster",
-                  "timeFrom" : "30s",
-                  "minSpan" : 3,
-                  "fontSize" : "80%",
-                  "nullPointMode" : "connected",
-                  "strokeWidth" : "1",
-                  "id" : 13,
-                  "pieType" : "pie",
-                  "legendType" : "Right side",
-                  "maxDataPoints" : "",
-                  "height" : "220",
-                  "datasource" : "Local",
-                  "aliasColors" : {},
-                  "format" : "none",
-                  "type" : "grafana-piechart-panel",
-                  "hideTimeOverride" : true,
-                  "valueName" : "current",
-                  "title" : "OSD Disk Size Summary",
-                  "timeShift" : null
-               },
-               {
-                  "fontSize" : "100%",
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "minSpan" : 2,
-                  "timeFrom" : "30s",
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "target" : "aliasByNode(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.stat_bytes),0),1),1,-2)",
-                        "refId" : "A"
-                     }
-                  ],
-                  "styles" : [
-                     {
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "type" : "date",
-                        "alias" : "Time"
-                     },
-                     {
-                        "unit" : "decbytes",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "decimals" : 0,
-                        "colorMode" : null,
-                        "pattern" : "Current",
-                        "alias" : "Disk Size"
-                     },
-                     {
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "Metric",
-                        "alias" : "Hostname.OSD Id"
-                     },
-                     {
-                        "alias" : "",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "/.*/",
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "pageSize" : 50,
-                  "span" : 2,
-                  "links" : [],
-                  "sort" : {
-                     "col" : 0,
-                     "desc" : false
-                  },
-                  "timeShift" : null,
-                  "title" : "OSD Size",
-                  "hideTimeOverride" : true,
-                  "type" : "table",
-                  "transform" : "timeseries_aggregations",
-                  "maxDataPoints" : "",
-                  "scroll" : true,
-                  "id" : 18
-               },
-               {
-                  "fontSize" : "80%",
-                  "nullPointMode" : "connected",
-                  "timeFrom" : "2m",
-                  "minSpan" : 2,
-                  "targets" : [
-                     {
-                        "target" : "currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0)",
-                        "hide" : true,
-                        "refId" : "C",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(countSeries(currentAbove(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0),0.5)),\"Encrypted\")",
-                        "hide" : false,
-                        "target" : "alias(countSeries(currentAbove(#C,0.5)),\"Encrypted\")",
-                        "refId" : "D"
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(countSeries(currentBelow(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0),0.5)),\"Non-Encrypted\")",
-                        "target" : "alias(countSeries(currentBelow(#C,0.5)),\"Non-Encrypted\")",
-                        "refId" : "E"
-                     }
-                  ],
-                  "combine" : {
-                     "threshold" : 0,
-                     "label" : "Others"
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "interval" : null,
-                  "legend" : {
-                     "percentage" : false,
-                     "values" : true,
-                     "show" : true
-                  },
-                  "cacheTimeout" : null,
-                  "valueName" : "current",
-                  "hideTimeOverride" : true,
-                  "title" : "OSD Encryption Summary",
-                  "timeShift" : null,
-                  "aliasColors" : {
-                     "Non-Encrypted" : "#E5AC0E"
-                  },
-                  "format" : "none",
-                  "type" : "grafana-piechart-panel",
-                  "maxDataPoints" : "1",
-                  "height" : "200px",
-                  "datasource" : null,
-                  "id" : 19,
-                  "strokeWidth" : 1,
-                  "pieType" : "pie",
-                  "legendType" : "Under graph"
-               },
-               {
-                  "fontSize" : "80%",
-                  "nullPointMode" : "connected",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "targets" : [
-                     {
-                        "refId" : "C",
-                        "target" : "currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0)",
-                        "hide" : true,
-                        "textEditor" : true
-                     },
-                     {
-                        "refId" : "D",
-                        "target" : "alias(countSeries(currentAbove(#C,0.5)), \"Bluestore\")",
-                        "hide" : false,
-                        "targetFull" : "alias(countSeries(currentAbove(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0),0.5)), \"Bluestore\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "targetFull" : "alias(countSeries(currentBelow(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0),0.5)), \"Filestore\")",
-                        "refId" : "E",
-                        "hide" : false,
-                        "target" : "alias(countSeries(currentBelow(#C,0.5)), \"Filestore\")"
-                     }
-                  ],
-                  "span" : 2,
-                  "interval" : null,
-                  "links" : [],
-                  "combine" : {
-                     "label" : "Others",
-                     "threshold" : 0
-                  },
-                  "cacheTimeout" : null,
-                  "legend" : {
-                     "percentage" : false,
-                     "values" : true,
-                     "show" : true
-                  },
-                  "valueName" : "current",
-                  "title" : "Summary of OSD Types",
-                  "hideTimeOverride" : true,
-                  "timeShift" : null,
-                  "aliasColors" : {
-                     "Non-Encrypted" : "#E5AC0E"
-                  },
-                  "type" : "grafana-piechart-panel",
-                  "format" : "none",
-                  "datasource" : null,
-                  "height" : "200px",
-                  "maxDataPoints" : "1",
-                  "pieType" : "pie",
-                  "id" : 20,
-                  "strokeWidth" : 1,
-                  "legendType" : "Under graph"
-               }
+        ], 
+        "refresh": "10s", 
+        "rows": [
+            {
+                "collapse": false, 
+                "height": "220px", 
+                "panels": [
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": "Local", 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "hideTimeOverride": true, 
+                        "id": 11, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": "", 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "timeFrom": "1m", 
+                        "title": "OSDs", 
+                        "type": "singlestat", 
+                        "valueFontSize": "80%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "avg"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": false, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(245, 54, 54, 0.9)", 
+                            "rgba(237, 129, 40, 0.89)", 
+                            "rgba(50, 172, 45, 0.97)"
+                        ], 
+                        "datasource": "Local", 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "hideTimeOverride": true, 
+                        "id": 12, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": 100, 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\"))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "", 
+                        "timeFrom": "1m", 
+                        "title": "OSDs UP", 
+                        "type": "singlestat", 
+                        "valueFontSize": "80%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "avg"
+                    }, 
+                    {
+                        "cacheTimeout": null, 
+                        "colorBackground": true, 
+                        "colorValue": false, 
+                        "colors": [
+                            "rgba(251,251,251,0.97)", 
+                            "rgba(255,165,0, 1)", 
+                            "rgba(245, 54, 54, 0.9)"
+                        ], 
+                        "datasource": "Local", 
+                        "decimals": 0, 
+                        "format": "none", 
+                        "gauge": {
+                            "maxValue": 100, 
+                            "minValue": 0, 
+                            "show": false, 
+                            "thresholdLabels": false, 
+                            "thresholdMarkers": true
+                        }, 
+                        "hideTimeOverride": true, 
+                        "id": 16, 
+                        "interval": null, 
+                        "links": [], 
+                        "mappingType": 1, 
+                        "mappingTypes": [
+                            {
+                                "name": "value to text", 
+                                "value": 1
+                            }, 
+                            {
+                                "name": "range to text", 
+                                "value": 2
+                            }
+                        ], 
+                        "maxDataPoints": 100, 
+                        "minSpan": 1, 
+                        "nullPointMode": "connected", 
+                        "nullText": null, 
+                        "postfix": "", 
+                        "postfixFontSize": "50%", 
+                        "prefix": "", 
+                        "prefixFontSize": "50%", 
+                        "rangeMaps": [
+                            {
+                                "from": "null", 
+                                "text": "N/A", 
+                                "to": "null"
+                            }
+                        ], 
+                        "span": 1, 
+                        "sparkline": {
+                            "fillColor": "rgba(31, 118, 189, 0.18)", 
+                            "full": false, 
+                            "lineColor": "rgb(31, 120, 193)", 
+                            "show": false
+                        }, 
+                        "tableColumn": "", 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "A", 
+                                "target": "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\"))", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "B", 
+                                "target": "keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\"))", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "diffSeries(#B,#A)", 
+                                "targetFull": "diffSeries(keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd), \"max\")),keepLastValue(consolidateBy(maxSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.mon.num_osd_up),\"max\")))", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": "1,3", 
+                        "timeFrom": "1m", 
+                        "title": "OSDs DOWN", 
+                        "type": "singlestat", 
+                        "valueFontSize": "80%", 
+                        "valueMaps": [
+                            {
+                                "op": "=", 
+                                "text": "N/A", 
+                                "value": "null"
+                            }
+                        ], 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "cacheTimeout": null, 
+                        "combine": {
+                            "label": "Others", 
+                            "threshold": 0
+                        }, 
+                        "datasource": "Local", 
+                        "description": "The pie chart shows the various disk sizes used within the cluster", 
+                        "fontSize": "80%", 
+                        "format": "none", 
+                        "height": "220", 
+                        "hideTimeOverride": true, 
+                        "id": 13, 
+                        "interval": null, 
+                        "legend": {
+                            "percentage": false, 
+                            "show": true, 
+                            "sortDesc": true, 
+                            "values": true
+                        }, 
+                        "legendType": "Right side", 
+                        "links": [], 
+                        "maxDataPoints": "", 
+                        "minSpan": 3, 
+                        "nullPointMode": "connected", 
+                        "pieType": "pie", 
+                        "span": 3, 
+                        "strokeWidth": "1", 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "A", 
+                                "target": "currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0)", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "B", 
+                                "target": "alias(currentBelow(#A,1099511627776),\"<1TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),\"<1TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "C", 
+                                "target": "alias(currentBelow(currentAbove(#A,1099511627776),2199023255552),\"2TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),2199023255552),\"2TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "Q", 
+                                "target": "alias(currentBelow(currentAbove(#A,2199023255552),3298534883328),\"3TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),2199023255552),3298534883328),\"3TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "D", 
+                                "target": "alias(currentBelow(currentAbove(#A,3298534883328),4398046511104),\"4TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),3298534883328),4398046511104),\"4TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "E", 
+                                "target": "alias(currentBelow(currentAbove(#A,4398046511104),6597069766656),\"6TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),4398046511104),6597069766656),\"6TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "F", 
+                                "target": "alias(currentBelow(currentAbove(#A,6597069766656),8796093022208),\"8TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),6597069766656),8796093022208),\"8TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "G", 
+                                "target": "alias(currentBelow(currentAbove(#A,8796093022208),10995116277760),\"10TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),8796093022208),10995116277760),\"10TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": true, 
+                                "refId": "H", 
+                                "target": "alias(currentBelow(currentAbove(#A,10995116277760),13194139533312),\"12TB\")", 
+                                "targetFull": "alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),10995116277760),13194139533312),\"12TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "I", 
+                                "target": "alias(countSeries(#B), \"<1TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),\"<1TB\")), \"<1TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "J", 
+                                "target": "alias(countSeries(#C), \"2TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),1099511627776),2199023255552),\"2TB\")), \"2TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "K", 
+                                "target": "alias(countSeries(#D), \"4TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),3298534883328),4398046511104),\"4TB\")), \"4TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "L", 
+                                "target": "alias(countSeries(#E), \"6TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),4398046511104),6597069766656),\"6TB\")), \"6TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "M", 
+                                "target": "alias(countSeries(#F), \"8TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),6597069766656),8796093022208),\"8TB\")), \"8TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "N", 
+                                "target": "alias(countSeries(#G), \"10TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),8796093022208),10995116277760),\"10TB\")), \"10TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "O", 
+                                "target": "alias(countSeries(#H), \"12TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),10995116277760),13194139533312),\"12TB\")), \"12TB\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "P", 
+                                "target": "alias(countSeries(#Q), \"3TB\")", 
+                                "targetFull": "alias(countSeries(alias(currentBelow(currentAbove(currentAbove(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.stat_bytes),0),2199023255552),3298534883328),\"3TB\")), \"3TB\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "30s", 
+                        "timeShift": null, 
+                        "title": "OSD Disk Size Summary", 
+                        "type": "grafana-piechart-panel", 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "fontSize": "100%", 
+                        "hideTimeOverride": true, 
+                        "id": 18, 
+                        "links": [], 
+                        "maxDataPoints": "", 
+                        "minSpan": 2, 
+                        "pageSize": 50, 
+                        "scroll": true, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": false
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Disk Size", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 0, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "decbytes"
+                            }, 
+                            {
+                                "alias": "Hostname.OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.stat_bytes),0),1),1,-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "30s", 
+                        "timeShift": null, 
+                        "title": "OSD Size", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "aliasColors": {
+                            "Non-Encrypted": "#E5AC0E"
+                        }, 
+                        "cacheTimeout": null, 
+                        "combine": {
+                            "label": "Others", 
+                            "threshold": 0
+                        }, 
+                        "datasource": null, 
+                        "fontSize": "80%", 
+                        "format": "none", 
+                        "height": "200px", 
+                        "hideTimeOverride": true, 
+                        "id": 19, 
+                        "interval": null, 
+                        "legend": {
+                            "percentage": false, 
+                            "show": true, 
+                            "values": true
+                        }, 
+                        "legendType": "Under graph", 
+                        "links": [], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 2, 
+                        "nullPointMode": "connected", 
+                        "pieType": "pie", 
+                        "span": 2, 
+                        "strokeWidth": 1, 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "C", 
+                                "target": "currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0)", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": false, 
+                                "refId": "D", 
+                                "target": "alias(countSeries(currentAbove(#C,0.5)),\"Encrypted\")", 
+                                "targetFull": "alias(countSeries(currentAbove(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0),0.5)),\"Encrypted\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "E", 
+                                "target": "alias(countSeries(currentBelow(#C,0.5)),\"Non-Encrypted\")", 
+                                "targetFull": "alias(countSeries(currentBelow(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.encrypted),-1),0),0.5)),\"Non-Encrypted\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "timeShift": null, 
+                        "title": "OSD Encryption Summary", 
+                        "type": "grafana-piechart-panel", 
+                        "valueName": "current"
+                    }, 
+                    {
+                        "aliasColors": {
+                            "Non-Encrypted": "#E5AC0E"
+                        }, 
+                        "cacheTimeout": null, 
+                        "combine": {
+                            "label": "Others", 
+                            "threshold": 0
+                        }, 
+                        "datasource": null, 
+                        "fontSize": "80%", 
+                        "format": "none", 
+                        "height": "200px", 
+                        "hideTimeOverride": true, 
+                        "id": 20, 
+                        "interval": null, 
+                        "legend": {
+                            "percentage": false, 
+                            "show": true, 
+                            "values": true
+                        }, 
+                        "legendType": "Under graph", 
+                        "links": [], 
+                        "maxDataPoints": "1", 
+                        "minSpan": 2, 
+                        "nullPointMode": "connected", 
+                        "pieType": "pie", 
+                        "span": 2, 
+                        "strokeWidth": 1, 
+                        "targets": [
+                            {
+                                "hide": true, 
+                                "refId": "C", 
+                                "target": "currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0)", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": false, 
+                                "refId": "D", 
+                                "target": "alias(countSeries(currentAbove(#C,0.5)), \"Bluestore\")", 
+                                "targetFull": "alias(countSeries(currentAbove(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0),0.5)), \"Bluestore\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "hide": false, 
+                                "refId": "E", 
+                                "target": "alias(countSeries(currentBelow(#C,0.5)), \"Filestore\")", 
+                                "targetFull": "alias(countSeries(currentBelow(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id_hidden.osd_type),-1),0),0.5)), \"Filestore\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "timeShift": null, 
+                        "title": "Summary of OSD Types", 
+                        "type": "grafana-piechart-panel", 
+                        "valueName": "current"
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "OSD Summary", 
+                "titleSize": "h5"
+            }, 
+            {
+                "collapse": true, 
+                "height": "500", 
+                "panels": [
+                    {
+                        "content": "<h1>Ceph Filestore I/O Process</h1>\n<p style=\"text-align: justify;\">\nA write request is first committed to a journal using direct-io (<i><b>apply</b></i>). Once this write is complete, the data is persisted to HDD by a second 'buffered' write operation (<i><b>commit</b></i>). The commit operation is basically a measure of time taken to perform a <i>syncfs</i> call to flush dirty pages to disk, and is therefore <b>not</b> a time associated with any specific client initiated operation.<p> The tables on the right show the top 10 OSDs with the highest latencies.\n", 
+                        "height": "300", 
+                        "id": 10, 
+                        "links": [], 
+                        "minSpan": 3, 
+                        "mode": "html", 
+                        "span": 3, 
+                        "title": "", 
+                        "type": "text"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Filestore OSDs", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 27, 
+                        "links": [], 
+                        "minSpan": 1, 
+                        "pageSize": null, 
+                        "scroll": true, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": true
+                        }, 
+                        "span": 1, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 0, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "none"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "hidden", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(currentBelow(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.osd_type),-1),0.5),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "timeShift": null, 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time spent in the queue for the journal. Excessive times here may indicate OSD tthrottling is happening. In this scenario you should review the OSD specific settings in \"ceph.conf\"; filestore_queue_max_ops or filestore_queue_max_bytes", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 3, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Journal Queue Time", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    ".001", 
+                                    ".003"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.queue_transaction_latency_avg),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time taken for the write request to be safely committed to the journal device", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 4, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Journal Latency", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    "0.01", 
+                                    "0.1"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.journal_latency),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Apply latency covers the time taken to commit to the journal and complete the transaction", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 5, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Apply Latency", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    "100", 
+                                    "500"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.apply_latency),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Commit latency is the time taken for writes to be flushed to disk as part of async kernel activity", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 6, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Commit Latency", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    "1", 
+                                    "3"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.commitcycle_latency),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "aliasColors": {
+                            "95%ile Commit Latency": "#447EBC", 
+                            "Apply Latency Max": "#890F02"
+                        }, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": "Local", 
+                        "description": "Shows the latency for a given OSD, allowing you to compare a specific OSD against the $percentile%ile graph. Note that when the \"OSD Id\" pull-down shows **ALL**, only the **first** OSD is shown to prevent the graph from being unreadable!", 
+                        "fill": 0, 
+                        "height": "300px", 
+                        "id": 1, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "maxDataPoints": "", 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [
+                            {
+                                "alias": "Apply Latency Max", 
+                                "fill": 0
+                            }, 
+                            {
+                                "alias": "95%ile Apply Latency", 
+                                "fill": 2
+                            }
+                        ], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.queue_transaction_latency_avg),0),1),\"Journal queue avg\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "B", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.journal_latency),0),1),\"Journal latency avg\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.apply_latency),0),1), \"Apply latency avg\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "D", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.commitcycle_latency),0),1),\"Commit latency avg\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Filestore Latency for OSD '$osd_id'", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "s", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": "Local", 
+                        "fill": 1, 
+                        "height": "300px", 
+                        "id": 9, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.queue_transaction_latency_avg,$percentile), \"journal Queue time\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "B", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.journal_latency,$percentile), \"journal Latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.apply_latency,$percentile), \"apply Latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "D", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.commitcycle_latency,$percentile), \"commit/flush Latency\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Filestore IO Summary - all OSD's @ $percentile%ile", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "s", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "Filestore OSD Latencies", 
+                "titleSize": "h5"
+            }, 
+            {
+                "collapse": true, 
+                "height": 250, 
+                "panels": [
+                    {
+                        "content": "<h1>Ceph Bluestore I/O Process</h1>\n<p style=\"text-align: justify;\">\nUnlike filestore, bluestore does not suffer from a double-write penalty (i.e write to journal then write to HDD). With bluestore, once a write is scheduled (<b>submit</b> and <b>throttle</b> latencies), it is done directly to the disk (<b>AIO wait</b>), and then the metadata relating to the object is changed (<b>kv_commit</b>). Writes are not considered complete until the kv store is updated. <p> The tables on the right focus on  the top 10 Bluestore OSDs with the highest latencies.\n", 
+                        "height": "300", 
+                        "id": 22, 
+                        "links": [], 
+                        "minSpan": 3, 
+                        "mode": "html", 
+                        "span": 3, 
+                        "title": "", 
+                        "type": "text"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Bluestore OSDs", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 26, 
+                        "links": [], 
+                        "minSpan": 1, 
+                        "pageSize": null, 
+                        "scroll": true, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 0, 
+                            "desc": true
+                        }, 
+                        "span": 1, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [], 
+                                "type": "hidden", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 0, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "none"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.osd_type),-1),0.5),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "timeShift": null, 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time spent preparing the request (transaction)", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 23, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": false
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Submit Latency", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    ".001", 
+                                    ".003"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.submit_lat),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time requests wait due to throttling or busy conditions", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 24, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "Throttle Latency", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    ".002", 
+                                    ".005"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [
+                                    ""
+                                ], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.throttle_lat),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time spent waiting for the physical I/O request to complete", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 29, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "AIO Wait Time", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    ".020", 
+                                    ".050"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.state_aio_wait_lat),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "columns": [
+                            {
+                                "text": "Current", 
+                                "value": "current"
+                            }
+                        ], 
+                        "description": "Time spent waiting for rocksdb (metadata store) to commit meta data", 
+                        "fontSize": "100%", 
+                        "height": "310", 
+                        "hideTimeOverride": true, 
+                        "id": 25, 
+                        "links": [], 
+                        "minSpan": 2, 
+                        "pageSize": 5, 
+                        "scroll": false, 
+                        "showHeader": true, 
+                        "sort": {
+                            "col": 1, 
+                            "desc": true
+                        }, 
+                        "span": 2, 
+                        "styles": [
+                            {
+                                "alias": "Time", 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "pattern": "Time", 
+                                "type": "date"
+                            }, 
+                            {
+                                "alias": "KV Commit ", 
+                                "colorMode": "row", 
+                                "colors": [
+                                    "rgba(50, 172, 45, 0.97)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(245, 54, 54, 0.9)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Current", 
+                                "thresholds": [
+                                    ".003", 
+                                    ".005"
+                                ], 
+                                "type": "number", 
+                                "unit": "s"
+                            }, 
+                            {
+                                "alias": "OSD Id", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss", 
+                                "decimals": 2, 
+                                "pattern": "Metric", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }, 
+                            {
+                                "alias": "", 
+                                "colorMode": null, 
+                                "colors": [
+                                    "rgba(245, 54, 54, 0.9)", 
+                                    "rgba(237, 129, 40, 0.89)", 
+                                    "rgba(50, 172, 45, 0.97)"
+                                ], 
+                                "decimals": 2, 
+                                "pattern": "/.*/", 
+                                "thresholds": [], 
+                                "type": "number", 
+                                "unit": "short"
+                            }
+                        ], 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.kv_commit_lat),0),$max_devices),-2)", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "timeFrom": "2m", 
+                        "title": "", 
+                        "transform": "timeseries_aggregations", 
+                        "type": "table"
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": null, 
+                        "fill": 1, 
+                        "height": "300", 
+                        "id": 21, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": true, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.submit_lat),0),$max_devices),\"submit latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "B", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.throttle_lat),0),$max_devices),\"throttle latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.state_aio_wait_lat),0),$max_devices),\"AIO Wait latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "D", 
+                                "target": "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.kv_commit_lat),0),$max_devices),\"KV Commit Latency\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "Bluestore Latency for OSD '$osd_id'", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "s", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }, 
+                    {
+                        "aliasColors": {}, 
+                        "bars": false, 
+                        "dashLength": 10, 
+                        "dashes": false, 
+                        "datasource": "Local", 
+                        "description": "This charts shows the $percentile%ile latencies across all OSDs, which indicates overall performance, but does not represent any specific OSD", 
+                        "fill": 1, 
+                        "height": "300px", 
+                        "id": 28, 
+                        "legend": {
+                            "avg": false, 
+                            "current": false, 
+                            "max": false, 
+                            "min": false, 
+                            "show": true, 
+                            "total": false, 
+                            "values": false
+                        }, 
+                        "lines": true, 
+                        "linewidth": 1, 
+                        "links": [], 
+                        "minSpan": 6, 
+                        "nullPointMode": "null", 
+                        "percentage": false, 
+                        "pointradius": 5, 
+                        "points": false, 
+                        "renderer": "flot", 
+                        "seriesOverrides": [], 
+                        "spaceLength": 10, 
+                        "span": 6, 
+                        "stack": false, 
+                        "steppedLine": false, 
+                        "targets": [
+                            {
+                                "refId": "A", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.submit_lat,$percentile), \"Submit Latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "B", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.throttle_lat,$percentile), \"Throttle Latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "C", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.state_aio_wait_lat,$percentile), \"IO Wait Latency\")", 
+                                "textEditor": true
+                            }, 
+                            {
+                                "refId": "D", 
+                                "target": "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.kv_commit_lat,$percentile), \"KV Commit Latency\")", 
+                                "textEditor": true
+                            }
+                        ], 
+                        "thresholds": [], 
+                        "timeFrom": null, 
+                        "timeShift": null, 
+                        "title": "BlueStore IO Summary - all OSD's @ $percentile%ile", 
+                        "tooltip": {
+                            "shared": true, 
+                            "sort": 0, 
+                            "value_type": "individual"
+                        }, 
+                        "type": "graph", 
+                        "xaxis": {
+                            "buckets": null, 
+                            "mode": "time", 
+                            "name": null, 
+                            "show": true, 
+                            "values": []
+                        }, 
+                        "yaxes": [
+                            {
+                                "format": "s", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": "0", 
+                                "show": true
+                            }, 
+                            {
+                                "format": "short", 
+                                "label": null, 
+                                "logBase": 1, 
+                                "max": null, 
+                                "min": null, 
+                                "show": false
+                            }
+                        ]
+                    }
+                ], 
+                "repeat": null, 
+                "repeatIteration": null, 
+                "repeatRowId": null, 
+                "showTitle": true, 
+                "title": "Bluestore OSD Latencies", 
+                "titleSize": "h5"
+            }
+        ], 
+        "schemaVersion": 14, 
+        "style": "dark", 
+        "tags": [
+            "overview"
+        ], 
+        "templating": {
+            "list": [
+                {
+                    "allValue": null, 
+                    "current": {
+                        "selected": true, 
+                        "text": "storage.lab", 
+                        "value": "storage.lab"
+                    }, 
+                    "hide": 2, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "domain", 
+                    "options": [
+                        {
+                            "selected": true, 
+                            "text": "storage.lab", 
+                            "value": "storage.lab"
+                        }
+                    ], 
+                    "query": "storage.lab", 
+                    "type": "custom"
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "selected": true, 
+                        "text": "ceph", 
+                        "value": "ceph"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 2, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "cluster_name", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.*", 
+                    "refresh": 1, 
+                    "regex": "", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "selected": true, 
+                        "text": "95", 
+                        "value": "95"
+                    }, 
+                    "hide": 0, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "percentile", 
+                    "options": [
+                        {
+                            "selected": true, 
+                            "text": "95", 
+                            "value": "95"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "96", 
+                            "value": "96"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "97", 
+                            "value": "97"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "98", 
+                            "value": "98"
+                        }, 
+                        {
+                            "selected": false, 
+                            "text": "99", 
+                            "value": "99"
+                        }
+                    ], 
+                    "query": "95,96,97,98,99", 
+                    "type": "custom"
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "selected": true, 
+                        "text": "10", 
+                        "value": "10"
+                    }, 
+                    "hide": 2, 
+                    "includeAll": false, 
+                    "label": null, 
+                    "multi": false, 
+                    "name": "max_devices", 
+                    "options": [
+                        {
+                            "selected": true, 
+                            "text": "10", 
+                            "value": "10"
+                        }
+                    ], 
+                    "query": "10", 
+                    "type": "custom"
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "text": "All", 
+                        "value": "$__all"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 0, 
+                    "includeAll": true, 
+                    "label": "OSD Id", 
+                    "multi": false, 
+                    "name": "osd_id", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*", 
+                    "refresh": 1, 
+                    "regex": "/^\\d+$/", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }, 
+                {
+                    "allValue": null, 
+                    "current": {
+                        "text": "All", 
+                        "value": "$__all"
+                    }, 
+                    "datasource": "Local", 
+                    "hide": 2, 
+                    "includeAll": true, 
+                    "label": "OSD Id", 
+                    "multi": false, 
+                    "name": "osd_id_hidden", 
+                    "options": [], 
+                    "query": "collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*", 
+                    "refresh": 1, 
+                    "regex": "/^\\d+$/", 
+                    "sort": 0, 
+                    "tagValuesQuery": "", 
+                    "tags": [], 
+                    "tagsQuery": "", 
+                    "type": "query", 
+                    "useTags": false
+                }
             ]
-         },
-         {
-            "repeat" : null,
-            "title" : "Filestore OSD Latencies",
-            "repeatIteration" : null,
-            "collapse" : true,
-            "repeatRowId" : null,
-            "height" : "500",
-            "titleSize" : "h5",
-            "panels" : [
-               {
-                  "minSpan" : 3,
-                  "type" : "text",
-                  "title" : "",
-                  "content" : "<h1>Ceph Filestore I/O Process</h1>\n<p style=\"text-align: justify;\">\nA write request is first committed to a journal using direct-io (<i><b>apply</b></i>). Once this write is complete, the data is persisted to HDD by a second 'buffered' write operation (<i><b>commit</b></i>). The commit operation is basically a measure of time taken to perform a <i>syncfs</i> call to flush dirty pages to disk, and is therefore <b>not</b> a time associated with any specific client initiated operation.<p> The tables on the right show the top 10 OSDs with the highest latencies.\n",
-                  "id" : 10,
-                  "links" : [],
-                  "span" : 3,
-                  "height" : "300",
-                  "mode" : "html"
-               },
-               {
-                  "targets" : [
-                     {
-                        "target" : "aliasByNode(currentBelow(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.osd_type),-1),0.5),-2)",
-                        "refId" : "A",
-                        "textEditor" : true
-                     }
-                  ],
-                  "styles" : [
-                     {
-                        "alias" : "Time",
-                        "type" : "date",
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss"
-                     },
-                     {
-                        "alias" : "",
-                        "pattern" : "",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss"
-                     },
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "none",
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "pattern" : "Metric",
-                        "colorMode" : null,
-                        "decimals" : 0,
-                        "alias" : "OSD Id"
-                     },
-                     {
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "pattern" : "Current",
-                        "alias" : "",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short",
-                        "thresholds" : [],
-                        "type" : "hidden",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ]
-                     },
-                     {
-                        "unit" : "short",
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "/.*/",
-                        "alias" : ""
-                     }
-                  ],
-                  "pageSize" : null,
-                  "links" : [],
-                  "span" : 1,
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 0
-                  },
-                  "fontSize" : "100%",
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "timeFrom" : "2m",
-                  "minSpan" : 1,
-                  "description" : "Filestore OSDs",
-                  "height" : "310",
-                  "scroll" : true,
-                  "id" : 27,
-                  "timeShift" : null,
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "type" : "table",
-                  "transform" : "timeseries_aggregations"
-               },
-               {
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "scroll" : false,
-                  "height" : "310",
-                  "id" : 3,
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "fontSize" : "100%",
-                  "description" : "Time spent in the queue for the journal. Excessive times here may indicate OSD tthrottling is happening. In this scenario you should review the OSD specific settings in \"ceph.conf\"; filestore_queue_max_ops or filestore_queue_max_bytes",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "styles" : [
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "pattern" : "Time",
-                        "alias" : "Time",
-                        "type" : "date"
-                     },
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s",
-                        "thresholds" : [
-                           ".001",
-                           ".003"
-                        ],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "decimals" : 2,
-                        "colorMode" : "row",
-                        "pattern" : "Current",
-                        "alias" : "Journal Queue Time"
-                     },
-                     {
-                        "alias" : "OSD Id",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "Metric",
-                        "thresholds" : [],
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short"
-                     },
-                     {
-                        "pattern" : "/.*/",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "alias" : "",
-                        "unit" : "short",
-                        "thresholds" : [],
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.queue_transaction_latency_avg),0),$max_devices),-2)"
-                     }
-                  ],
-                  "sort" : {
-                     "col" : 1,
-                     "desc" : true
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "pageSize" : 5
-               },
-               {
-                  "height" : "310",
-                  "scroll" : false,
-                  "id" : 4,
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "styles" : [
-                     {
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "alias" : "Time",
-                        "type" : "date"
-                     },
-                     {
-                        "thresholds" : [
-                           "0.01",
-                           "0.1"
-                        ],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s",
-                        "alias" : "Journal Latency",
-                        "decimals" : 2,
-                        "colorMode" : "row",
-                        "pattern" : "Current"
-                     },
-                     {
-                        "pattern" : "Metric",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "alias" : "OSD Id",
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : []
-                     },
-                     {
-                        "alias" : "",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "pattern" : "/.*/",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.journal_latency),0),$max_devices),-2)"
-                     }
-                  ],
-                  "pageSize" : 5,
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 1
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "columns" : [
-                     {
-                        "text" : "Current",
-                        "value" : "current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "fontSize" : "100%",
-                  "timeFrom" : "2m",
-                  "minSpan" : 2,
-                  "description" : "Time taken for the write request to be safely committed to the journal device"
-               },
-               {
-                  "description" : "Apply latency covers the time taken to commit to the journal and complete the transaction",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "showHeader" : true,
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "fontSize" : "100%",
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 1
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "pageSize" : 5,
-                  "styles" : [
-                     {
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "alias" : "Time",
-                        "type" : "date"
-                     },
-                     {
-                        "thresholds" : [
-                           "100",
-                           "500"
-                        ],
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "type" : "number",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s",
-                        "alias" : "Apply Latency",
-                        "decimals" : 2,
-                        "colorMode" : "row",
-                        "pattern" : "Current"
-                     },
-                     {
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "alias" : "OSD Id",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "pattern" : "Metric"
-                     },
-                     {
-                        "alias" : "",
-                        "pattern" : "/.*/",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.apply_latency),0),$max_devices),-2)",
-                        "refId" : "A",
-                        "textEditor" : true
-                     }
-                  ],
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "id" : 5,
-                  "scroll" : false,
-                  "height" : "310"
-               },
-               {
-                  "sort" : {
-                     "col" : 1,
-                     "desc" : true
-                  },
-                  "links" : [],
-                  "span" : 2,
-                  "pageSize" : 5,
-                  "styles" : [
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "pattern" : "Time",
-                        "type" : "date",
-                        "alias" : "Time"
-                     },
-                     {
-                        "alias" : "Commit Latency",
-                        "decimals" : 2,
-                        "colorMode" : "row",
-                        "pattern" : "Current",
-                        "thresholds" : [
-                           "1",
-                           "3"
-                        ],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s"
-                     },
-                     {
-                        "pattern" : "Metric",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "alias" : "OSD Id",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short",
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ]
-                     },
-                     {
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "unit" : "short",
-                        "alias" : "",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "/.*/"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.commitcycle_latency),0),$max_devices),-2)",
-                        "refId" : "A"
-                     }
-                  ],
-                  "description" : "Commit latency is the time taken for writes to be flushed to disk as part of async kernel activity",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "fontSize" : "100%",
-                  "id" : 6,
-                  "scroll" : false,
-                  "height" : "310",
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "title" : "",
-                  "hideTimeOverride" : true
-               },
-               {
-                  "type" : "graph",
-                  "thresholds" : [],
-                  "aliasColors" : {
-                     "Apply Latency Max" : "#890F02",
-                     "95%ile Commit Latency" : "#447EBC"
-                  },
-                  "stack" : false,
-                  "timeShift" : null,
-                  "title" : "Filestore Latency for OSD '$osd_id'",
-                  "bars" : false,
-                  "id" : 1,
-                  "datasource" : "Local",
-                  "height" : "300px",
-                  "percentage" : false,
-                  "timeFrom" : null,
-                  "yaxes" : [
-                     {
-                        "label" : null,
-                        "min" : "0",
-                        "format" : "s",
-                        "show" : true,
-                        "logBase" : 1,
-                        "max" : null
-                     },
-                     {
-                        "min" : null,
-                        "label" : null,
-                        "format" : "short",
-                        "show" : false,
-                        "logBase" : 1,
-                        "max" : null
-                     }
-                  ],
-                  "description" : "Shows the latency for a given OSD, allowing you to compare a specific OSD against the $percentile%ile graph. Note that when the \"OSD Id\" pull-down shows **ALL**, only the **first** OSD is shown to prevent the graph from being unreadable!",
-                  "lines" : true,
-                  "linewidth" : 1,
-                  "renderer" : "flot",
-                  "dashes" : false,
-                  "links" : [],
-                  "targets" : [
-                     {
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.queue_transaction_latency_avg),0),1),\"Journal queue avg\")",
-                        "refId" : "A",
-                        "textEditor" : true
-                     },
-                     {
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.journal_latency),0),1),\"Journal latency avg\")",
-                        "refId" : "B",
-                        "textEditor" : true
-                     },
-                     {
-                        "refId" : "C",
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.apply_latency),0),1), \"Apply latency avg\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "refId" : "D",
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.commitcycle_latency),0),1),\"Commit latency avg\")"
-                     }
-                  ],
-                  "steppedLine" : false,
-                  "spaceLength" : 10,
-                  "dashLength" : 10,
-                  "xaxis" : {
-                     "values" : [],
-                     "mode" : "time",
-                     "show" : true,
-                     "name" : null,
-                     "buckets" : null
-                  },
-                  "pointradius" : 5,
-                  "points" : false,
-                  "seriesOverrides" : [
-                     {
-                        "fill" : 0,
-                        "alias" : "Apply Latency Max"
-                     },
-                     {
-                        "fill" : 2,
-                        "alias" : "95%ile Apply Latency"
-                     }
-                  ],
-                  "maxDataPoints" : "",
-                  "minSpan" : 6,
-                  "tooltip" : {
-                     "value_type" : "individual",
-                     "shared" : true,
-                     "sort" : 0
-                  },
-                  "fill" : 0,
-                  "nullPointMode" : "null",
-                  "legend" : {
-                     "values" : false,
-                     "max" : false,
-                     "total" : false,
-                     "current" : false,
-                     "show" : true,
-                     "avg" : false,
-                     "min" : false
-                  },
-                  "span" : 6
-               },
-               {
-                  "stack" : false,
-                  "timeShift" : null,
-                  "title" : "Filestore IO Summary - all OSD's @ $percentile%ile",
-                  "type" : "graph",
-                  "thresholds" : [],
-                  "aliasColors" : {},
-                  "datasource" : "Local",
-                  "height" : "300px",
-                  "percentage" : false,
-                  "id" : 9,
-                  "bars" : false,
-                  "linewidth" : 1,
-                  "lines" : true,
-                  "renderer" : "flot",
-                  "timeFrom" : null,
-                  "yaxes" : [
-                     {
-                        "min" : "0",
-                        "label" : null,
-                        "show" : true,
-                        "format" : "s",
-                        "logBase" : 1,
-                        "max" : null
-                     },
-                     {
-                        "logBase" : 1,
-                        "max" : null,
-                        "label" : null,
-                        "min" : null,
-                        "show" : false,
-                        "format" : "short"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.queue_transaction_latency_avg,$percentile), \"journal Queue time\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.journal_latency,$percentile), \"journal Latency\")",
-                        "refId" : "B"
-                     },
-                     {
-                        "textEditor" : true,
-                        "refId" : "C",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.apply_latency,$percentile), \"apply Latency\")"
-                     },
-                     {
-                        "textEditor" : true,
-                        "refId" : "D",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.commitcycle_latency,$percentile), \"commit/flush Latency\")"
-                     }
-                  ],
-                  "steppedLine" : false,
-                  "spaceLength" : 10,
-                  "dashLength" : 10,
-                  "dashes" : false,
-                  "links" : [],
-                  "pointradius" : 5,
-                  "xaxis" : {
-                     "show" : true,
-                     "name" : null,
-                     "buckets" : null,
-                     "values" : [],
-                     "mode" : "time"
-                  },
-                  "points" : false,
-                  "seriesOverrides" : [],
-                  "nullPointMode" : "null",
-                  "minSpan" : 6,
-                  "tooltip" : {
-                     "sort" : 0,
-                     "shared" : true,
-                     "value_type" : "individual"
-                  },
-                  "fill" : 1,
-                  "legend" : {
-                     "min" : false,
-                     "avg" : false,
-                     "show" : true,
-                     "current" : false,
-                     "total" : false,
-                     "max" : false,
-                     "values" : false
-                  },
-                  "span" : 6
-               }
-            ],
-            "showTitle" : true
-         },
-         {
-            "repeat" : null,
-            "title" : "Bluestore OSD Latencies",
-            "repeatIteration" : null,
-            "collapse" : true,
-            "repeatRowId" : null,
-            "height" : 250,
-            "titleSize" : "h5",
-            "showTitle" : true,
-            "panels" : [
-               {
-                  "height" : "300",
-                  "mode" : "html",
-                  "content" : "<h1>Ceph Bluestore I/O Process</h1>\n<p style=\"text-align: justify;\">\nUnlike filestore, bluestore does not suffer from a double-write penalty (i.e write to journal then write to HDD). With bluestore, once a write is scheduled (<b>submit</b> and <b>throttle</b> latencies), it is done directly to the disk (<b>AIO wait</b>), and then the metadata relating to the object is changed (<b>kv_commit</b>). Writes are not considered complete until the kv store is updated. <p> The tables on the right focus on  the top 10 Bluestore OSDs with the highest latencies.\n",
-                  "span" : 3,
-                  "links" : [],
-                  "id" : 22,
-                  "title" : "",
-                  "type" : "text",
-                  "minSpan" : 3
-               },
-               {
-                  "timeShift" : null,
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "height" : "310",
-                  "scroll" : true,
-                  "id" : 26,
-                  "columns" : [
-                     {
-                        "text" : "Current",
-                        "value" : "current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "fontSize" : "100%",
-                  "minSpan" : 1,
-                  "timeFrom" : "2m",
-                  "description" : "Bluestore OSDs",
-                  "styles" : [
-                     {
-                        "alias" : "Time",
-                        "type" : "date",
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss"
-                     },
-                     {
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "alias" : "",
-                        "pattern" : "",
-                        "colorMode" : null,
-                        "decimals" : 2
-                     },
-                     {
-                        "thresholds" : [],
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "hidden",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short",
-                        "alias" : "",
-                        "pattern" : "Current",
-                        "decimals" : 2,
-                        "colorMode" : null
-                     },
-                     {
-                        "unit" : "none",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "decimals" : 0,
-                        "colorMode" : null,
-                        "pattern" : "Metric",
-                        "alias" : "OSD Id"
-                     },
-                     {
-                        "alias" : "",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "/.*/",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "aliasByNode(currentAbove(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.osd_type),-1),0.5),-2)",
-                        "textEditor" : true
-                     }
-                  ],
-                  "pageSize" : null,
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 0
-                  },
-                  "span" : 1,
-                  "links" : []
-               },
-               {
-                  "title" : "",
-                  "hideTimeOverride" : true,
-                  "type" : "table",
-                  "transform" : "timeseries_aggregations",
-                  "scroll" : false,
-                  "height" : "310",
-                  "id" : 23,
-                  "fontSize" : "100%",
-                  "showHeader" : true,
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "description" : "Time spent preparing the request (transaction)",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.submit_lat),0),$max_devices),-2)",
-                        "textEditor" : true
-                     }
-                  ],
-                  "styles" : [
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "pattern" : "Time",
-                        "type" : "date",
-                        "alias" : "Time"
-                     },
-                     {
-                        "pattern" : "Current",
-                        "decimals" : 2,
-                        "colorMode" : "row",
-                        "alias" : "Submit Latency",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s",
-                        "thresholds" : [
-                           ".001",
-                           ".003"
-                        ],
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "type" : "number"
-                     },
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short",
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "pattern" : "Metric",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "alias" : "OSD Id"
-                     },
-                     {
-                        "alias" : "",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "pattern" : "/.*/",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "links" : [],
-                  "span" : 2,
-                  "sort" : {
-                     "col" : 1,
-                     "desc" : false
-                  },
-                  "pageSize" : 5
-               },
-               {
-                  "description" : "Time requests wait due to throttling or busy conditions",
-                  "timeFrom" : "2m",
-                  "minSpan" : 2,
-                  "columns" : [
-                     {
-                        "text" : "Current",
-                        "value" : "current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "fontSize" : "100%",
-                  "sort" : {
-                     "col" : 1,
-                     "desc" : true
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "pageSize" : 5,
-                  "styles" : [
-                     {
-                        "type" : "date",
-                        "alias" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "pattern" : "Time"
-                     },
-                     {
-                        "alias" : "Throttle Latency",
-                        "pattern" : "Current",
-                        "colorMode" : "row",
-                        "decimals" : 2,
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "thresholds" : [
-                           ".002",
-                           ".005"
-                        ],
-                        "unit" : "s",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss"
-                     },
-                     {
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short",
-                        "thresholds" : [
-                           ""
-                        ],
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "type" : "number",
-                        "pattern" : "Metric",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "alias" : "OSD Id"
-                     },
-                     {
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "pattern" : "/.*/",
-                        "alias" : "",
-                        "unit" : "short",
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ]
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.throttle_lat),0),$max_devices),-2)",
-                        "textEditor" : true
-                     }
-                  ],
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "hideTimeOverride" : true,
-                  "title" : "",
-                  "id" : 24,
-                  "scroll" : false,
-                  "height" : "310"
-               },
-               {
-                  "links" : [],
-                  "span" : 2,
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 1
-                  },
-                  "pageSize" : 5,
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.state_aio_wait_lat),0),$max_devices),-2)"
-                     }
-                  ],
-                  "styles" : [
-                     {
-                        "type" : "date",
-                        "alias" : "Time",
-                        "pattern" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss"
-                     },
-                     {
-                        "pattern" : "Current",
-                        "colorMode" : "row",
-                        "decimals" : 2,
-                        "alias" : "AIO Wait Time",
-                        "unit" : "s",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [
-                           ".020",
-                           ".050"
-                        ]
-                     },
-                     {
-                        "unit" : "short",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "pattern" : "Metric",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "alias" : "OSD Id"
-                     },
-                     {
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "thresholds" : [],
-                        "unit" : "short",
-                        "alias" : "",
-                        "pattern" : "/.*/",
-                        "decimals" : 2,
-                        "colorMode" : null
-                     }
-                  ],
-                  "description" : "Time spent waiting for the physical I/O request to complete",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "fontSize" : "100%",
-                  "columns" : [
-                     {
-                        "text" : "Current",
-                        "value" : "current"
-                     }
-                  ],
-                  "showHeader" : true,
-                  "id" : 29,
-                  "scroll" : false,
-                  "height" : "310",
-                  "type" : "table",
-                  "transform" : "timeseries_aggregations",
-                  "hideTimeOverride" : true,
-                  "title" : ""
-               },
-               {
-                  "hideTimeOverride" : true,
-                  "title" : "",
-                  "transform" : "timeseries_aggregations",
-                  "type" : "table",
-                  "scroll" : false,
-                  "height" : "310",
-                  "id" : 25,
-                  "showHeader" : true,
-                  "columns" : [
-                     {
-                        "value" : "current",
-                        "text" : "Current"
-                     }
-                  ],
-                  "fontSize" : "100%",
-                  "description" : "Time spent waiting for rocksdb (metadata store) to commit meta data",
-                  "minSpan" : 2,
-                  "timeFrom" : "2m",
-                  "styles" : [
-                     {
-                        "type" : "date",
-                        "alias" : "Time",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "pattern" : "Time"
-                     },
-                     {
-                        "alias" : "KV Commit ",
-                        "colorMode" : "row",
-                        "decimals" : 2,
-                        "pattern" : "Current",
-                        "thresholds" : [
-                           ".003",
-                           ".005"
-                        ],
-                        "colors" : [
-                           "rgba(50, 172, 45, 0.97)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(245, 54, 54, 0.9)"
-                        ],
-                        "type" : "number",
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "s"
-                     },
-                     {
-                        "alias" : "OSD Id",
-                        "pattern" : "Metric",
-                        "decimals" : 2,
-                        "colorMode" : null,
-                        "thresholds" : [],
-                        "type" : "number",
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "dateFormat" : "YYYY-MM-DD HH:mm:ss",
-                        "unit" : "short"
-                     },
-                     {
-                        "alias" : "",
-                        "pattern" : "/.*/",
-                        "colorMode" : null,
-                        "decimals" : 2,
-                        "colors" : [
-                           "rgba(245, 54, 54, 0.9)",
-                           "rgba(237, 129, 40, 0.89)",
-                           "rgba(50, 172, 45, 0.97)"
-                        ],
-                        "type" : "number",
-                        "thresholds" : [],
-                        "unit" : "short"
-                     }
-                  ],
-                  "targets" : [
-                     {
-                        "textEditor" : true,
-                        "refId" : "A",
-                        "target" : "aliasByNode(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.kv_commit_lat),0),$max_devices),-2)"
-                     }
-                  ],
-                  "sort" : {
-                     "desc" : true,
-                     "col" : 1
-                  },
-                  "span" : 2,
-                  "links" : [],
-                  "pageSize" : 5
-               },
-               {
-                  "bars" : false,
-                  "id" : 21,
-                  "datasource" : null,
-                  "percentage" : false,
-                  "height" : "300",
-                  "thresholds" : [],
-                  "aliasColors" : {},
-                  "type" : "graph",
-                  "title" : "Bluestore Latency for OSD '$osd_id'",
-                  "stack" : true,
-                  "timeShift" : null,
-                  "links" : [],
-                  "dashes" : false,
-                  "spaceLength" : 10,
-                  "dashLength" : 10,
-                  "targets" : [
-                     {
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.submit_lat),0),$max_devices),\"submit latency\")",
-                        "refId" : "A",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "refId" : "B",
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.throttle_lat),0),$max_devices),\"throttle latency\")"
-                     },
-                     {
-                        "refId" : "C",
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.state_aio_wait_lat),0),$max_devices),\"AIO Wait latency\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "target" : "alias(limit(transformNull(keepLastValue(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.$osd_id.kv_commit_lat),0),$max_devices),\"KV Commit Latency\")",
-                        "refId" : "D"
-                     }
-                  ],
-                  "steppedLine" : false,
-                  "timeFrom" : null,
-                  "yaxes" : [
-                     {
-                        "show" : true,
-                        "format" : "s",
-                        "min" : "0",
-                        "label" : null,
-                        "max" : null,
-                        "logBase" : 1
-                     },
-                     {
-                        "logBase" : 1,
-                        "max" : null,
-                        "min" : null,
-                        "label" : null,
-                        "show" : false,
-                        "format" : "short"
-                     }
-                  ],
-                  "renderer" : "flot",
-                  "linewidth" : 1,
-                  "lines" : true,
-                  "points" : false,
-                  "seriesOverrides" : [],
-                  "xaxis" : {
-                     "show" : true,
-                     "buckets" : null,
-                     "name" : null,
-                     "values" : [],
-                     "mode" : "time"
-                  },
-                  "pointradius" : 5,
-                  "span" : 6,
-                  "legend" : {
-                     "total" : false,
-                     "max" : false,
-                     "values" : false,
-                     "min" : false,
-                     "show" : true,
-                     "avg" : false,
-                     "current" : false
-                  },
-                  "fill" : 1,
-                  "minSpan" : 6,
-                  "tooltip" : {
-                     "sort" : 0,
-                     "value_type" : "individual",
-                     "shared" : true
-                  },
-                  "nullPointMode" : "null"
-               },
-               {
-                  "description" : "This charts shows the $percentile%ile latencies across all OSDs, which indicates overall performance, but does not represent any specific OSD",
-                  "timeFrom" : null,
-                  "yaxes" : [
-                     {
-                        "format" : "s",
-                        "show" : true,
-                        "label" : null,
-                        "min" : "0",
-                        "max" : null,
-                        "logBase" : 1
-                     },
-                     {
-                        "format" : "short",
-                        "show" : false,
-                        "label" : null,
-                        "min" : null,
-                        "max" : null,
-                        "logBase" : 1
-                     }
-                  ],
-                  "renderer" : "flot",
-                  "linewidth" : 1,
-                  "lines" : true,
-                  "links" : [],
-                  "dashes" : false,
-                  "spaceLength" : 10,
-                  "dashLength" : 10,
-                  "targets" : [
-                     {
-                        "refId" : "A",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.submit_lat,$percentile), \"Submit Latency\")",
-                        "textEditor" : true
-                     },
-                     {
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.throttle_lat,$percentile), \"Throttle Latency\")",
-                        "refId" : "B",
-                        "textEditor" : true
-                     },
-                     {
-                        "textEditor" : true,
-                        "refId" : "C",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.state_aio_wait_lat,$percentile), \"IO Wait Latency\")"
-                     },
-                     {
-                        "refId" : "D",
-                        "target" : "alias(percentileOfSeries(collectd.*.$domain.cephmetrics.gauge.$cluster_name.osd.*.kv_commit_lat,$percentile), \"KV Commit Latency\")",
-                        "textEditor" : true
-                     }
-                  ],
-                  "steppedLine" : false,
-                  "thresholds" : [],
-                  "aliasColors" : {},
-                  "type" : "graph",
-                  "title" : "BlueStore IO Summary - all OSD's @ $percentile%ile",
-                  "stack" : false,
-                  "timeShift" : null,
-                  "id" : 28,
-                  "bars" : false,
-                  "datasource" : "Local",
-                  "percentage" : false,
-                  "height" : "300px",
-                  "fill" : 1,
-                  "minSpan" : 6,
-                  "tooltip" : {
-                     "sort" : 0,
-                     "value_type" : "individual",
-                     "shared" : true
-                  },
-                  "nullPointMode" : "null",
-                  "span" : 6,
-                  "legend" : {
-                     "min" : false,
-                     "current" : false,
-                     "show" : true,
-                     "avg" : false,
-                     "total" : false,
-                     "values" : false,
-                     "max" : false
-                  },
-                  "xaxis" : {
-                     "values" : [],
-                     "mode" : "time",
-                     "show" : true,
-                     "buckets" : null,
-                     "name" : null
-                  },
-                  "pointradius" : 5,
-                  "points" : false,
-                  "seriesOverrides" : []
-               }
+        }, 
+        "time": {
+            "from": "now-1h", 
+            "to": "now"
+        }, 
+        "timepicker": {
+            "refresh_intervals": [
+                "5s", 
+                "10s", 
+                "30s", 
+                "1m", 
+                "5m", 
+                "15m", 
+                "30m", 
+                "1h", 
+                "2h", 
+                "1d"
+            ], 
+            "time_options": [
+                "5m", 
+                "15m", 
+                "1h", 
+                "6h", 
+                "12h", 
+                "24h", 
+                "2d", 
+                "7d", 
+                "30d"
             ]
-         }
-      ],
-      "refresh" : "10s",
-      "annotations" : {
-         "list" : []
-      },
-      "timezone" : "browser",
-      "gnetId" : null,
-      "links" : [
-         {
-            "asDropdown" : true,
-            "tags" : [
-               "overview"
-            ],
-            "title" : "Shortcuts",
-            "type" : "dashboards",
-            "icon" : "external link"
-         }
-      ]
-   },
-   "meta" : {
-      "createdBy" : "admin",
-      "slug" : "ceph-osd-information",
-      "canEdit" : true,
-      "canStar" : true,
-      "expires" : "0001-01-01T00:00:00Z",
-      "version" : 38,
-      "canSave" : true,
-      "updatedBy" : "admin",
-      "type" : "db",
-      "created" : "2017-08-03T21:42:28Z",
-      "updated" : "2017-08-21T00:59:02Z"
-   }
+        }, 
+        "timezone": "browser", 
+        "title": "Ceph OSD Information", 
+        "version": 3
+    }, 
+    "meta": {
+        "canEdit": true, 
+        "canSave": true, 
+        "canStar": true, 
+        "created": "2017-10-06T01:14:09Z", 
+        "createdBy": "admin@localhost", 
+        "expires": "0001-01-01T00:00:00Z", 
+        "slug": "ceph-osd-information", 
+        "type": "db", 
+        "updated": "2017-10-06T01:17:19Z", 
+        "updatedBy": "admin@localhost", 
+        "version": 3
+    }
 }


### PR DESCRIPTION
ceph-at-a-glance: Capacity util panel now links directly to the capacity
chart in the ceph-cluster dashboard BZ 1496198

ceph-osd-information: query timespan changed from the default 1hr to 1m
aligning to the OSDs panel query on the 'at-a-glance' dashboard
BZ 1498504