### PR TITLE
Tweak Vonage panel color in newer versions

### DIFF
--- a/ansible/roles/ceph-grafana/tasks/grafana_plugins.yml
+++ b/ansible/roles/ceph-grafana/tasks/grafana_plugins.yml
@@ -16,7 +16,15 @@
   command: "grafana-cli plugins update {{ item }}"
   with_items: "{{ grafana_plugins }}"
 
-- name: Update status-panel for readability within the 'light' theme
+- name: Update status-panel for readability within the 'light' theme (older versions)
   command: "sed -i.bak -e 's/green/rgb(1,167,1)/g' /var/lib/grafana/plugins/vonage-status-panel/dist/css/status_panel.css"
   tags:
     - skip_ansible_lint
+
+- name: Update status-panel for readability within the 'light' theme (newer versions)
+  replace:
+    path: "/var/lib/grafana/plugins/vonage-status-panel/dist/status_ctrl.js"
+    regexp:  "ok: 'rgba\\(50, 128, 45, 0\\.9\\)',"
+    replace: "ok: 'rgb(1,167,1)',"
+    backup: no
+  failed_when: false


### PR DESCRIPTION
The plugin recently added a system for configurable colors, breaking our
earlier hack. Add a new one.

See: https://github.com/Vonage/Grafana_Status_panel/commit/8633ba23bb2f336342ba3f7002a07be597b6e816

Signed-off-by: Zack Cerza <zack@redhat.com>