### PR TITLE
collectors: No update on fetch osd_stats failure

### DIFF
--- a/collectors/osd.py
+++ b/collectors/osd.py
@@ -295,8 +295,12 @@ class OSDs(BaseCollector):
             if osd_type in OSDs.supported_object_stores:
 
                 osd_stats = self._fetch_osd_stats(osd_id, osd_type)
-                osd_device = self.osd[osd_id]
-                osd_device.update(osd_stats)
+                if osd_stats:
+                    osd_device = self.osd[osd_id]
+                    osd_device.update(osd_stats)
+                else:
+                    self.logger.warning("OSD stats for osd.{} not "
+                                        "available".format(osd_id))
 
             else:
                 self.logger.warning("Unknown OSD type encountered for "


### PR DESCRIPTION
We currently do not check that we were able to successfully fetch the
osd_stas for a given osd_id which can result in collectors being down
for a while. We should check that we were able to fetch them before we
actually try to update them.

Signed-off-by: Boris Ranto <branto@redhat.com>