### PR TITLE
Require libsemanage-python on collector nodes

### DIFF
--- a/cephmetrics.spec.in
+++ b/cephmetrics.spec.in
@@ -43,6 +43,7 @@ The vonage status panel and piechart panel for grafana web server.
 Summary:	Ceph metrics collectors
 Requires:	collectd
 Requires:	collectd-python
+Requires:	libsemanage-python
 %description collectors
 The collectors for Ceph implemented with help of statistics collection daemon collectd.
 


### PR DESCRIPTION
This is required by ansible in order to enable the `collectd_tcp_network_connect` boolean