### PR TITLE
Fix a typo in the purge.yml Ansible playbook file

### DIFF
--- a/ansible/purge.yml
+++ b/ansible/purge.yml
@@ -31,7 +31,7 @@
       state: absent
     with_items:
       - /var/lib/graphite
-      - /var/lig/graphite-web
+      - /var/lib/graphite-web
       - /var/lib/grafana
       - /var/lib/carbon
       - /etc/grafana/grafana.ini


### PR DESCRIPTION
This request is for fixing a typo found in the purge.yml file during some testing of a Ceph Metrics cluster.

The file lists /var/lig/graphite-web rather than /var/lib/graphite-web
