### PR TITLE
Configure collected for short hostname

### DIFF
--- a/ansible/purge.yml
+++ b/ansible/purge.yml
@@ -31,7 +31,7 @@
       state: absent
     with_items:
       - /var/lib/graphite
-      - /var/lig/graphite-web
+      - /var/lib/graphite-web
       - /var/lib/grafana
       - /var/lib/carbon
       - /etc/grafana/grafana.ini

--- a/ansible/roles/ceph-collectd/tasks/configure_collectd.yml
+++ b/ansible/roles/ceph-collectd/tasks/configure_collectd.yml
@@ -5,6 +5,13 @@
     dest: "{{ collectd_conf }}"
   notify: Restart collectd
 
+- name: Make sure collected uses shor hostanem in collectd.conf
+  replace:
+    dest: "{{ collectd_conf }}"
+    regexp: 'Hostname ".*"'
+    replace: 'Hostname "{{ ansible_hostname }}"'
+  notify: Restart collectd
+
 - name: Set PluginDir in collectd.conf
   replace:
     dest: "{{ collectd_conf }}"

--- a/etc/collectd.conf
+++ b/etc/collectd.conf
@@ -1,4 +1,4 @@
-# Hostname "obj-mon-1.storage.lab"
+Hostname "obj-mon-1.storage.lab"
 BaseDir "/var/lib/collectd"
 PluginDir "/usr/lib64/collectd"
 


### PR DESCRIPTION
Problem:
In some specific cases, due to the system configuration, collectd daemon may start using a long hostname creating problem in the data structure being collected.

Fix:
Make sure we configure collectd, via the Hostname parameter of the /etc/collectd.conf file, to use the short hostname.

Illustration
Shows how the configuration on our test system created an unexpected data tree structure for collected.

![cephmetricsdatatree](https://user-images.githubusercontent.com/5449242/34000370-d6514480-e0cb-11e7-9edc-ba5d12b37b04.png)
 