### PR TITLE
ansible: Set CPU quotas on containers

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -6,6 +6,8 @@ defaults:
   update_alerts: false
   grafana:
     container_name: "grafana/grafana"
+    container_cpu_period: 100000
+    container_cpu_cores: 2
     # version currently only applies to containers
     version: 5.0.4
     datasource: Local

--- a/ansible/roles/ceph-grafana/tasks/setup_container.yml
+++ b/ansible/roles/ceph-grafana/tasks/setup_container.yml
@@ -40,6 +40,8 @@
       - name: "{{ docker.network_name }}"
     keep_volumes: true
     pull: true
+    cpu_period: "{{ grafana.container_cpu_period }}"
+    cpu_quota: "{{ grafana.container_cpu_period * grafana.container_cpu_cores }}"
     env:
       GF_INSTALL_PLUGINS: "{{ grafana.plugins|join(',') }}"
 

--- a/ansible/roles/ceph-prometheus/defaults/main.yml
+++ b/ansible/roles/ceph-prometheus/defaults/main.yml
@@ -2,6 +2,8 @@
 defaults:
   prometheus:
     container_name: prom/prometheus
+    container_cpu_period: 100000
+    container_cpu_cores: 2
     version: latest
     data_dir: /var/lib/cephmetrics
     user_id: '65534'  # This is the UID used by the prom/prometheus docker image

--- a/ansible/roles/ceph-prometheus/tasks/setup_container.yml
+++ b/ansible/roles/ceph-prometheus/tasks/setup_container.yml
@@ -21,4 +21,8 @@
     user: "{{ prometheus.user_id }}"
     keep_volumes: true
     pull: true
+    cpu_period: "{{ prometheus.container_cpu_period }}"
+    # As of ansible-2.5.2, this module doesn't support the equivalent of the
+    # --cpus flag, so we must use period/quota for now
+    cpu_quota: "{{ prometheus.container_cpu_period * prometheus.container_cpu_cores }}"
   notify: Service handler


### PR DESCRIPTION
We want to default to limiting each container to two cores. While docker
has a nicer way to do this, it isn't supported by ansible as of 2.5.2.
It's easy enough to use the slightly more awkward method, however.

Signed-off-by: Zack Cerza <zack@redhat.com>