### PR TITLE
Unpin testinfra

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps=
   ansible
   pytest
   pytest-xdist
-  git+https://github.com/zmc/testinfra.git@fix-xdist-ansible#egg=testinfra
+  testinfra
 changedir=ansible
 commands=
   py.test -v -n auto --connection=ansible --ansible-inventory {posargs} ./roles/


### PR DESCRIPTION
1.14.0 has been released with the fix we needed.

Signed-off-by: Zack Cerza <zack@redhat.com>