### PR TITLE
Updated to use OS metrics from default scrape job

### DIFF
--- a/dashboards/mgr-prometheus/iscsi-overview.json
+++ b/dashboards/mgr-prometheus/iscsi-overview.json
@@ -4,13 +4,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.4"
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "grafana-piechart-panel",
       "name": "Pie Chart",
-      "version": "1.3.0"
+      "version": "1.3.3"
     },
     {
       "type": "panel",
@@ -54,7 +54,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1526263169717,
+  "iteration": 1530144424365,
   "links": [
     {
       "asDropdown": true,
@@ -840,11 +840,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  (sum(\n      rate(\n           node_network_transmit_bytes{job=\"iscsi-gateways\"}[30s])\n     ) by(instance)),\n     \"IP\", \"$1\",\"instance\",\"(.*)\\\\:.*\")",
+          "expr": "label_replace(\n  (sum(\n      rate(\n           node_network_transmit_bytes{job=\"node\", instance=~\"($iscsi_gws).*\"}[30s])\n     ) by(instance)),\n     \"gw_name\", \"$1\",\"instance\",\"([^.]*).*\")",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "{{IP}}",
+          "legendFormat": "{{gw_name}}",
           "refId": "B"
         }
       ],
@@ -977,10 +977,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "round(sum by(IP) (label_replace((rate(ceph_iscsi_lun_iops[30s])),\"IP\",\"$1\",\"instance\",\"(.*)\\\\:.*\")))",
+              "expr": "round(\n  sum by(gw_name) \n    (rate(ceph_iscsi_lun_iops[30s])\n  )\n)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{IP}}",
+              "legendFormat": "{{gw_name}}",
               "refId": "A"
             }
           ],
@@ -1026,7 +1026,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Local",
+          "datasource": null,
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -1059,10 +1059,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "round(sum by(IP) (label_replace((rate(ceph_iscsi_lun_read_bytes[30s])),\"IP\",\"$1\",\"instance\",\"(.*)\\\\:.*\") + (label_replace((rate(ceph_iscsi_lun_write_bytes[30s])),\"IP\",\"$1\",\"instance\",\"(.*)\\\\:.*\")) ))",
+              "expr": "round(\n  sum by(gw_name) \n    ((rate(ceph_iscsi_lun_read_bytes[30s])) + \n    (rate(ceph_iscsi_lun_write_bytes[30s]))\n    )\n  )",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{IP}}",
+              "legendFormat": "{{gw_name}}",
               "refId": "A"
             }
           ],
@@ -1141,10 +1141,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - (avg by (IP) (label_replace(irate(node_cpu{job=\"iscsi-gateways\",mode=\"idle\"}[30s]),\"IP\",\"$1\",\"instance\",\"(.*):(.*)\")) * 100)",
+              "expr": "100 - (avg by (gw) \n        (label_replace(\n          irate(node_cpu{job=\"node\",instance=~\"($iscsi_gws).*\",mode=\"idle\"}[30s]),\n         \"gw\",\"$1\",\"instance\",\"([^.]*).*\")\n        ) * 100)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{IP}}",
+              "legendFormat": "{{gw}}",
               "refId": "B"
             }
           ],
@@ -1221,10 +1221,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(((node_memory_MemTotal{job=\"iscsi-gateways\"} - node_memory_MemFree) / node_memory_MemTotal) * 100, \"IP\", \"$1\", \"instance\",\"(.*):(.*)\")",
+              "expr": "label_replace(\n  ((node_memory_MemTotal{job=\"node\", instance=~\"($iscsi_gws).*\"} - node_memory_MemFree) / node_memory_MemTotal) * 100, \n  \"gw\", \"$1\", \"instance\",\"([^.]*).*\")",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{IP}}",
+              "legendFormat": "{{gw}}",
               "refId": "D"
             }
           ],
@@ -1290,7 +1290,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 12
           },
           "id": 17,
           "legend": {
@@ -1372,7 +1372,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 19
           },
           "id": 19,
           "legend": {
@@ -1495,6 +1495,26 @@
         ],
         "query": "(eth|bon|en|ib|mlx)",
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "iscsi_gws",
+        "options": [],
+        "query": "label_values(ceph_iscsi_scrape_duration_seconds, gw_name)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -1530,5 +1550,5 @@
   },
   "timezone": "",
   "title": "iSCSI Overview",
-  "version": 30
+  "version": 38
 }


### PR DESCRIPTION
All node_exporter scrapes are now done under the
same job (called node) so the dashboard now uses
an updated template query to identify the correct
host to pull out the OS metrics by iscsi gateway

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>