### PR TITLE
rpm: use_epel is no longer defined

### DIFF
--- a/patches/0001-ansible-Disable-devel_mode.patch
+++ b/patches/0001-ansible-Disable-devel_mode.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] ansible: Disable devel_mode
 
 Signed-off-by: Boris Ranto <branto@redhat.com>
 ---
- ansible/roles/cephmetrics-common/tasks/merge_vars.yml | 7 +++++++
- 1 file changed, 7 insertions(+)
+ ansible/roles/cephmetrics-common/tasks/merge_vars.yml | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/ansible/roles/cephmetrics-common/tasks/merge_vars.yml b/ansible/roles/cephmetrics-common/tasks/merge_vars.yml
 index f8dbcd0..15d2a6b 100644
 --- a/ansible/roles/cephmetrics-common/tasks/merge_vars.yml
 +++ b/ansible/roles/cephmetrics-common/tasks/merge_vars.yml
-@@ -3,3 +3,10 @@
+@@ -3,3 +3,9 @@
    set_fact: {"{{ item }}": "{% if vars[item] is not defined %}{{ defaults[item] }}{% elif vars[item] is mapping %}{{ defaults[item]|combine(vars[item]|default({})) }}{% else %}{{ vars[item] }}{% endif %}"}
    with_items: "{{ defaults.keys() }}"
    no_log: true
@@ -21,7 +21,6 @@ index f8dbcd0..15d2a6b 100644
 +  assert:
 +    that:
 +      - devel_mode == False
-+      - use_epel == False
 +    msg: "Devel mode is not supported in the downstream builds"
 -- 
 2.9.5


### PR DESCRIPTION
We need to strip this away from the downstream patch.