### PR TITLE
Fix units used for throughput

### DIFF
--- a/dashboards/cephmetrics-graphite/ceph-pools.json
+++ b/dashboards/cephmetrics-graphite/ceph-pools.json
@@ -146,7 +146,7 @@
                         }, 
                         "yaxes": [
                             {
-                                "format": "bytes", 
+                                "format": "decbytes", 
                                 "label": null, 
                                 "logBase": 1, 
                                 "max": null, 
@@ -220,7 +220,7 @@
                         }, 
                         "yaxes": [
                             {
-                                "format": "bytes", 
+                                "format": "decbytes", 
                                 "label": null, 
                                 "logBase": 1, 
                                 "max": null, 
@@ -385,7 +385,7 @@
                                 "pattern": "Current", 
                                 "thresholds": [], 
                                 "type": "number", 
-                                "unit": "bytes"
+                                "unit": "decbytes"
                             }, 
                             {
                                 "alias": "", 

--- a/dashboards/mgr-prometheus/ceph-pools.json
+++ b/dashboards/mgr-prometheus/ceph-pools.json
@@ -503,7 +503,7 @@
           "pattern": "Value",
           "thresholds": [],
           "type": "number",
-          "unit": "bytes"
+          "unit": "decbytes"
         }
       ],
       "targets": [
@@ -825,7 +825,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "decbytes",
               "label": "",
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
Throughput units were using binary representation,
whereas the expected unit is decimal (i.e.
MB/s not MiB/s)


Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1496186

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>