### PR TITLE
ansible: Support non-default cluster name

### DIFF
--- a/ansible/group_vars/all.yml.sample
+++ b/ansible/group_vars/all.yml.sample
@@ -1,5 +1,7 @@
 dummy:
 
+#cluster_name: ceph
+
 #containerized: true
 
 # Set the backend options, mgr+prometheus or cephmetrics+graphite

--- a/ansible/roles/ceph-mgr/tasks/main.yml
+++ b/ansible/roles/ceph-mgr/tasks/main.yml
@@ -25,4 +25,4 @@
   when: container_name != ""
 
 - name: Enable mgr prometheus module
-  command: "{{ mgr_prefix|default('') }} ceph mgr module enable prometheus"
+  command: "{{ mgr_prefix|default('') }} ceph --cluster {{ cluster_name }} mgr module enable prometheus"

--- a/ansible/roles/cephmetrics-common/defaults/main.yml
+++ b/ansible/roles/cephmetrics-common/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 defaults:
+  cluster_name: ceph
   containerized: true
   backend:
     metrics: mgr  # mgr, cephmetrics


### PR DESCRIPTION
Signed-off-by: Boris Ranto <branto@redhat.com>

We only call the ceph command once and the command fails for non-standard cluster names. This should fix it, see the downstream bz for the details:

https://bugzilla.redhat.com/show_bug.cgi?id=1608863