### PR TITLE
Only run ceph-mgr role on a single node

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,7 +6,7 @@
   - always
 
 - hosts:
-  - mgrs
+  - mgrs[0]
   become: true
   roles:
   - ceph-mgr


### PR DESCRIPTION
We do not need to run the ceph-mgr role multiple times. The command that
enables the module only need to be run on one of the machines, choosing
first as it is the easiest.

Signed-off-by: Boris Ranto <branto@redhat.com>