### PR TITLE
ceph-node-exporter: Fix defaults for service_name

### DIFF
--- a/ansible/roles/ceph-node-exporter/defaults/main.yml
+++ b/ansible/roles/ceph-node-exporter/defaults/main.yml
@@ -9,4 +9,4 @@ defaults:
         - prometheus-node-exporter
       yum:
         - prometheus-node_exporter
-  service_name: node_exporter
+    service_name: node_exporter


### PR DESCRIPTION
Indentation was off.

Signed-off-by: Zack Cerza <zack@redhat.com>