### PR TITLE
Fix health state colors

### DIFF
--- a/dashboards/mgr-prometheus/ceph-at-a-glance.json
+++ b/dashboards/mgr-prometheus/ceph-at-a-glance.json
@@ -745,17 +745,12 @@
         {
           "from": "1",
           "text": "WARN",
-          "to": "4"
+          "to": "1"
         },
         {
-          "from": "5",
+          "from": "2",
           "text": "ERROR",
-          "to": "99"
-        },
-        {
-          "from": "-10",
-          "text": "NODATA",
-          "to": "0"
+          "to": "2"
         }
       ],
       "sparkline": {
@@ -774,7 +769,7 @@
           "textEditor": true
         }
       ],
-      "thresholds": "1,5",
+      "thresholds": "1,2",
       "timeFrom": "1m",
       "timeShift": null,
       "title": "Health",
@@ -789,12 +784,12 @@
         {
           "op": "=",
           "text": "WARN",
-          "value": "4"
+          "value": "1"
         },
         {
           "op": "=",
           "text": "ERROR",
-          "value": "8"
+          "value": "2"
         }
       ],
       "valueName": "current"

--- a/dashboards/mgr-prometheus/ceph-health.json
+++ b/dashboards/mgr-prometheus/ceph-health.json
@@ -105,22 +105,17 @@
         {
           "from": "0",
           "text": "HEALTH OK",
-          "to": "1"
+          "to": "0"
         },
         {
           "from": "1",
           "text": "HEALTH WARNING",
-          "to": "4"
+          "to": "1"
         },
         {
-          "from": "5",
+          "from": "2",
           "text": "HEALTH ERROR",
-          "to": "99"
-        },
-        {
-          "from": "-10",
-          "text": "NODATA",
-          "to": "0"
+          "to": "2"
         }
       ],
       "sparkline": {
@@ -140,7 +135,7 @@
           "textEditor": true
         }
       ],
-      "thresholds": "1,5",
+      "thresholds": "1,2",
       "timeFrom": "1m",
       "timeShift": null,
       "title": "",
@@ -276,7 +271,7 @@
               "format": "short",
               "label": "",
               "logBase": 1,
-              "max": "2",
+              "max": "3",
               "min": "-0.5",
               "show": false
             },


### PR DESCRIPTION
Two dashboards were translating the values from
ceph_health_status incorrectly, resulting in
the wrong health state being shown.

Closes: https://github.com/ceph/cephmetrics/issues/202

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>