### PR TITLE
dashboards: Fix cluster OSDs panel

### DIFF
--- a/dashboards/mgr-prometheus/ceph-cluster.json
+++ b/dashboards/mgr-prometheus/ceph-cluster.json
@@ -593,7 +593,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(max by (id) (ceph_osd_metadata))",
+          "expr": "count(max by (ceph_daemon) (ceph_osd_metadata))",
           "format": "time_series",
           "groupBy": [],
           "intervalFactor": 2,


### PR DESCRIPTION
We still use the old 'id' label for getting the number of OSDs in the
ceph cluster dashboard. However, the label was superseded by the
'ceph_daemon' label in one of the updates to the prometheus exporter in
ceph-mgr. This patch changes the query to what we use in other
dashboards -- i.e. 'ceph_daemon' instead of 'id'.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1627725

Signed-off-by: Boris Ranto <branto@redhat.com>