### PR TITLE
 Make SMTP, anonymous login and theme configuratebil 

### DIFF
--- a/ansible/group_vars/all.yml.sample
+++ b/ansible/group_vars/all.yml.sample
@@ -18,3 +18,12 @@ dummy:
 #grafana:
 #  admin_user: admin
 #  admin_password: admin
+# You may want to change the default theme to dark
+#  default_theme: light
+# If you use email alerting, configure your SMTP connection. If your SMTP Server dos not require authentication, skip smtp_user and smtp_password
+#  smtp_enabled: false
+#  smtp_host: smtp.mail.example.com:25
+#  smtp_user: username
+#  smtp_password: password
+# If you like to enable Anonymous login, set auth_anonymous to true
+#  auth_anonymous: false

--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -19,6 +19,9 @@ defaults:
     # New deployments work fine
     admin_user: admin
     admin_password: admin
+    default_theme: light
+    snmp_enabled: false
+    auth_anonymous: false
     plugins:
       - vonage-status-panel
       - grafana-piechart-panel

--- a/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -55,6 +55,64 @@
   no_log: true
   tags: [ini]
 
+- name: Set grafana default_theme grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: users
+    option: default_theme
+    value: "{{ grafana.default_theme }}"
+  no_log: true
+  tags: [ini]
+
+- name: Set SMTP configuration in grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: smtp
+    option: enabled
+    value: "{{ grafana.smtp_enabled }}"
+  no_log: true
+  tags: [ini]
+
+- name: Set SMTP host in grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: smtp
+    option: host
+    value: "{{ grafana.smtp_host }}"
+  no_log: true
+  tags: [ini]
+  when: grafana.smtp_enabled
+
+- name: Set SMTP user in grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: smtp
+    option: user
+    value: "{{ grafana.smtp_user }}"
+  no_log: true
+  tags: [ini]
+  when: grafana.smtp_enabled and grafana.smtp_user is defined
+
+- name: Set SMTP password in grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: smtp
+    option: password
+    value: "{{ grafana.smtp_password }}"
+  no_log: true
+  tags: [ini]
+  when: grafana.smtp_enabled and grafana.smtp_password is defined
+
+- name: Set anonymous login in grafana.ini
+  ini_file:
+    path: /etc/grafana/grafana.ini
+    section: auth.anonymous
+    option: enabled
+    value: "{{ grafana.auth_anonymous }}"
+  no_log: true
+  tags: [ini]
+  when: grafana.auth_anonymous
+
 - include: grafana_plugins.yml
   when:
     - devel_mode


### PR DESCRIPTION
We are using cepmetrics for alerting via mail. Each time something changes at the deployment our SMTP settings get overwritten. With these changes, basic SMTP settings can be done via variables.  
We also use status monitors, displaying some grafana playlists. Those monitors should not be that bright, that's why we prefer to use the dark theme, which can now also be configured via variables.  
Finlay, we use anonymous login for those monitoring displays (also configurable now :-) )
