### PR TITLE
Prevent pull images for prometheus and grafana

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -14,6 +14,7 @@ defaults:
     version: latest
     uid: 472
     datasource: Local
+    pull_image: true
     # You need to change these in the web UI on an already deployed machine, first
     # New deployments work fine
     admin_user: admin

--- a/ansible/roles/ceph-grafana/tasks/setup_container.yml
+++ b/ansible/roles/ceph-grafana/tasks/setup_container.yml
@@ -39,7 +39,7 @@
     networks:
       - name: "{{ docker.network_name }}"
     keep_volumes: true
-    pull: true
+    pull: "{{ grafana.pull_image }}"
     cpu_period: "{{ grafana.container_cpu_period }}"
     # As of ansible-2.5.2, this module doesn't support the equivalent of the
     # --cpus flag, so we must use period/quota for now

--- a/ansible/roles/ceph-prometheus/defaults/main.yml
+++ b/ansible/roles/ceph-prometheus/defaults/main.yml
@@ -9,6 +9,7 @@ defaults:
     # This is passed directly to the docker_container module. It is only used
     # for containerized deployments.
     etc_hosts: {}
+    pull_image: true
     version: latest
     data_dir: /var/lib/cephmetrics
     user_id: '65534'  # This is the UID used by the prom/prometheus docker image

--- a/ansible/roles/ceph-prometheus/tasks/setup_container.yml
+++ b/ansible/roles/ceph-prometheus/tasks/setup_container.yml
@@ -21,7 +21,7 @@
     etc_hosts: "{{ prometheus.etc_hosts }}"
     user: "{{ prometheus.user_id }}"
     keep_volumes: true
-    pull: true
+    pull: "{{ prometheus.pull_image }}"
     cpu_period: "{{ prometheus.container_cpu_period }}"
     # As of ansible-2.5.2, this module doesn't support the equivalent of the
     # --cpus flag, so we must use period/quota for now


### PR DESCRIPTION
This patch add a new prometheus and grafana variable to allow install when the images already pulled on docker.