### PR TITLE
dashboards: Show only open sessions

### DIFF
--- a/dashboards/mgr-prometheus/mds-performance.json
+++ b/dashboards/mgr-prometheus/mds-performance.json
@@ -281,7 +281,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(ceph_mds_sessions_session_count)",
+          "expr": "sum(ceph_mds_sessions_sessions_open)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
We should use 'ceph_mds_sessions_sessions_open' instead of
'ceph_mds_sessions_session_count' to compute the number of (active)
clients. Otherwise, we include all the sessions, including the stale
ones.

Resolves: rhbz#1652896
Signed-off-by: Boris Ranto <branto@redhat.com>

This should fix the following downstream bz: https://bugzilla.redhat.com/show_bug.cgi?id=1652896