### PR TITLE
Allow skipping image verification

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -15,6 +15,7 @@ defaults:
     uid: 472
     datasource: Local
     pull_image: true
+    trust_image_content: false
     # You need to change these in the web UI on an already deployed machine, first
     # New deployments work fine
     admin_user: admin

--- a/ansible/roles/ceph-grafana/tasks/setup_container.yml
+++ b/ansible/roles/ceph-grafana/tasks/setup_container.yml
@@ -40,6 +40,7 @@
       - name: "{{ docker.network_name }}"
     keep_volumes: true
     pull: "{{ grafana.pull_image }}"
+    trust_image_content: "{{ grafana.trust_image_content }}"
     cpu_period: "{{ grafana.container_cpu_period }}"
     # As of ansible-2.5.2, this module doesn't support the equivalent of the
     # --cpus flag, so we must use period/quota for now

--- a/ansible/roles/ceph-prometheus/defaults/main.yml
+++ b/ansible/roles/ceph-prometheus/defaults/main.yml
@@ -10,6 +10,7 @@ defaults:
     # for containerized deployments.
     etc_hosts: {}
     pull_image: true
+    trust_image_content: false
     version: latest
     data_dir: /var/lib/cephmetrics
     user_id: '65534'  # This is the UID used by the prom/prometheus docker image

--- a/ansible/roles/ceph-prometheus/tasks/setup_container.yml
+++ b/ansible/roles/ceph-prometheus/tasks/setup_container.yml
@@ -22,6 +22,7 @@
     user: "{{ prometheus.user_id }}"
     keep_volumes: true
     pull: "{{ prometheus.pull_image }}"
+    trust_image_content: "{{ prometheus.trust_image_content }}"
     cpu_period: "{{ prometheus.container_cpu_period }}"
     # As of ansible-2.5.2, this module doesn't support the equivalent of the
     # --cpus flag, so we must use period/quota for now


### PR DESCRIPTION
For the prometheus and grafana containers, in some specific
circumstances it's desirable to skip verification of the container
image. Allow passing that value in via group_vars.

Resolves: rhbz#1636136
Signed-off-by: Zack Cerza <zack@redhat.com>