### PR TITLE
grafana: Add option to preserve grafana config

### DIFF
--- a/ansible/group_vars/all.yml.sample
+++ b/ansible/group_vars/all.yml.sample
@@ -27,3 +27,7 @@ dummy:
 #  smtp_password: password
 # If you like to enable Anonymous login, set auth_anonymous to true
 #  auth_anonymous: false
+# You can change this option if you want to keep your custom grafana configuration.
+# The script will still update the grafana config with the other configured options
+# but it won't overwrite your custom options.
+#  overwrite_config: true

--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -23,6 +23,10 @@ defaults:
     default_theme: light
     snmp_enabled: false
     auth_anonymous: false
+    # You can change this option if you want to keep your custom grafana configuration.
+    # The script will still update the grafana config with the other configured options
+    # but it won't overwrite your custom options.
+    overwrite_config: true
     plugins:
       - vonage-status-panel
       - grafana-piechart-panel

--- a/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/ansible/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -16,6 +16,7 @@
     owner: root
     group: grafana
     mode: 0640
+    force: "{{ grafana.overwrite_config }}"
   tags: [ini]
 
 - name: Set owner on /etc/grafana


### PR DESCRIPTION
This patch adds the grafana.overwrite_config option. You can change this
option if you want to keep your custom grafana configuration. The
scripts will still update the grafana config with the other configured
options but it won't overwrite your custom options.

Signed-off-by: Boris Ranto <branto@redhat.com>

This should fix the following bz: https://bugzilla.redhat.com/show_bug.cgi?id=1697336