### PR TITLE
grafana: Fix typo in smtp configuration

### DIFF
--- a/ansible/roles/ceph-grafana/defaults/main.yml
+++ b/ansible/roles/ceph-grafana/defaults/main.yml
@@ -21,7 +21,7 @@ defaults:
     admin_user: admin
     admin_password: admin
     default_theme: light
-    snmp_enabled: false
+    smtp_enabled: false
     auth_anonymous: false
     # You can change this option if you want to keep your custom grafana configuration.
     # The script will still update the grafana config with the other configured options


### PR DESCRIPTION
The typo actually makes the ansible run fail if you don't have
smtp_enabled defined anywhere else.

Signed-off-by: Boris Ranto <branto@redhat.com>