### PR TITLE
prometheus: Silence no data alerts

### DIFF
--- a/dashboards/mgr-prometheus/alert-status.json
+++ b/dashboards/mgr-prometheus/alert-status.json
@@ -96,7 +96,7 @@
         "frequency": "10s",
         "handler": 1,
         "name": "Overall Ceph Health alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1
@@ -231,7 +231,7 @@
         "frequency": "60s",
         "handler": 1,
         "name": "Ceph Error State alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1
@@ -898,7 +898,7 @@
         "frequency": "60s",
         "handler": 1,
         "name": "OSD Host Loss Check alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1
@@ -1162,7 +1162,7 @@
         "frequency": "30s",
         "handler": 1,
         "name": "Network Errors alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1
@@ -1291,7 +1291,7 @@
         "frequency": "60s",
         "handler": 1,
         "name": "Pool Capacity alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1
@@ -1555,7 +1555,7 @@
         "frequency": "60s",
         "handler": 1,
         "name": "Cluster Capacity alert",
-        "noDataState": "no_data",
+        "noDataState": "ok",
         "notifications": [
           {
             "id": 1


### PR DESCRIPTION
Currently, we are sending an e-mail to the admin when the query returns
no data. This can get annoying as it does not mean that the alert has
actually been hit. We should fix this and alert only if the query says
we should.

Resolves: https://bugzilla.redhat.com/1663289

Signed-off-by: Boris Ranto <branto@redhat.com>