### PR TITLE
Revert "Only run ceph-mgr role on a single node"

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,7 +6,7 @@
   - always
 
 - hosts:
-  - mgrs[0]
+  - mgrs
   become: true
   roles:
   - ceph-mgr


### PR DESCRIPTION
This reverts commit 6f7559dfbb7b38463cf5c5d31f6ba1d8c7dcef0c.

We need to re-run the role on all mgr nodes to get firewalling rules properly updated.