### PR TITLE
Revert comparison "fix" from ansible-lint

### DIFF
--- a/ansible/roles/ceph-mgr/tasks/main.yml
+++ b/ansible/roles/ceph-mgr/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Prefix the mgr command with a docker command
   set_fact:
     mgr_prefix: "docker exec {{ container_name }}"
-  when: container_name
+  when: container_name != ""  # noqa 602
 
 - name: Enable mgr prometheus module
   command: "{{ mgr_prefix|default('') }} ceph --cluster {{ cluster_name }} mgr module enable prometheus"


### PR DESCRIPTION
In d737083, we thought we were fixing something, but it turns out the
comparison suggested will throw an error if container_name contains a
dash (which it likely will). Revert the change and instruct
ansible-lint to not complain about that error on that line.

Resolves: rhbz#1731919

Signed-off-by: Zack Cerza <zack@redhat.com>