### PR TITLE
Replacing usage of group 'all' by dynamic generated group

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,5 +1,32 @@
 ---
-- hosts: all
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ceph_groups:
+      - ceph-grafana
+      # These are roles used by ceph-ansible
+      - mons
+      - agents
+      - osds
+      - mdss
+      - rgws
+      - nfss
+      - restapis
+      - rbdmirrors
+      - clients
+      - mgrs
+      - iscsis
+      # This role is (so far) only used for testing
+      - cluster
+  tasks:
+    - name: Creating one group containing all ceph groups - ceph_all
+      add_host:
+        name: "{{ item }}"
+        groups: "ceph_all"
+      loop: "{{ lookup('inventory_hostnames', ceph_groups|join(':'), wantlist=True) }}"
+
+- hosts: ceph_all
   gather_facts: true
   any_errors_fatal: true
   tags:

--- a/ansible/roles/ceph-prometheus/templates/prometheus.yml
+++ b/ansible/roles/ceph-prometheus/templates/prometheus.yml
@@ -16,7 +16,7 @@ scrape_configs:
 {% endfor %}
   - job_name: 'node'
     static_configs:
-{% for host in (groups['all'] | difference(groups['ceph-grafana'])) %}
+{% for host in (groups['ceph_all'] | difference(groups['ceph-grafana'])) %}
       - targets: ['{{ host }}:9100']
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"


### PR DESCRIPTION
Replacing usage of group 'all' by dynamic generated group containing all ceph groups.
Fixes #247  

Signed-off-by: rppietrzak <rpietrza@redhat.com>