### PR TITLE
DNM: dashboards: Fix broken disk latency chart

### DIFF
--- a/dashboards/mgr-prometheus/latency-by-server.json
+++ b/dashboards/mgr-prometheus/latency-by-server.json
@@ -90,7 +90,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(\n    (irate(node_disk_read_time_ms[30s]) + irate(node_disk_write_time_ms[30s]) / \n    (irate(node_disk_reads_completed[30s]) + irate(node_disk_writes_completed[30s])) +\n    ignoring(ceph_daemon,job,wal_device) ceph_disk_occupation))\n    by(instance)",
+          "expr": "max(\n  (\n    (irate(node_disk_read_time_ms[30s]) + irate(node_disk_write_time_ms[30s])) / \n    (irate(node_disk_reads_completed[30s]) + irate(node_disk_writes_completed[30s])) +\n    ignoring(ceph_daemon,job,wal_device) ceph_disk_occupation\n  )\n) by(instance)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",


### PR DESCRIPTION
The "All OSD Hosts - Highest Latency" chart's query was missing a
parenthesis, throwing numbers off by large amounts.

Resolves: rhbz#1650209
Signed-off-by: Zack Cerza <zack@redhat.com>