### PR TITLE
ceph-at-a-glance: Fix Disk IOPS/Throughput

### DIFF
--- a/dashboards/mgr-prometheus/ceph-at-a-glance.json
+++ b/dashboards/mgr-prometheus/ceph-at-a-glance.json
@@ -62,7 +62,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1526962541471,
+  "iteration": 1594326505937,
   "links": [
     {
       "asDropdown": true,
@@ -2599,7 +2599,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n  sum(\n    rate(\n      node_disk_reads_completed[$__interval]\n    )\n  ) by (instance,device)\n   + ignoring(ceph_daemon,job,wal_device) group_right(instance) ceph_disk_occupation\n)\n+\nsum(\n  sum(\n    rate(\n      node_disk_writes_completed[$__interval]\n    )\n  ) by (instance,device)\n   + ignoring(ceph_daemon,job,wal_device) group_right(instance) ceph_disk_occupation\n)",
+          "expr": "sum(\n  sum(\n    rate(\n      node_disk_reads_completed[$__interval]\n    )\n  ) by (instance,device)\n   + ignoring(ceph_daemon,job,wal_device,db_device) group_right(instance) ceph_disk_occupation\n)\n+\nsum(\n  sum(\n    rate(\n      node_disk_writes_completed[$__interval]\n    )\n  ) by (instance,device)\n   + ignoring(ceph_daemon,job,wal_device,db_device) group_right(instance) ceph_disk_occupation\n)",
           "format": "time_series",
           "groupBy": [],
           "hide": false,
@@ -2708,7 +2708,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "# should only include OSD hosts\nsum(\n  sum(\n    rate(\n      node_disk_bytes_read[$__interval]\n    )\n  ) by (instance,device)\n  + ignoring(ceph_daemon,job,wal_device) group_right(instance) ceph_disk_occupation\n)\n+\nsum(\n  sum(\n    rate(\n      node_disk_bytes_written[$__interval]\n    )\n  ) by (instance,device)\n  + ignoring(ceph_daemon,job,wal_device) group_right(instance) ceph_disk_occupation\n)",
+          "expr": "# should only include OSD hosts\nsum(\n  sum(\n    rate(\n      node_disk_bytes_read[$__interval]\n    )\n  ) by (instance,device)\n  + ignoring(ceph_daemon,job,wal_device,db_device) group_right(instance) ceph_disk_occupation\n)\n+\nsum(\n  sum(\n    rate(\n      node_disk_bytes_written[$__interval]\n    )\n  ) by (instance,device)\n  + ignoring(ceph_daemon,job,wal_device,db_device) group_right(instance) ceph_disk_occupation\n)",
           "format": "time_series",
           "groupBy": [],
           "hide": false,
@@ -3243,5 +3243,5 @@
   },
   "timezone": "browser",
   "title": "Ceph - At A Glance",
-  "version": 43
+  "version": 44
 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 skipsdist = True
 envlist=ansible-lint,ansible-syntax,flake8,dashboards
 
+[testenv]
+basepython=python2
+
 [testenv:ansible-lint]
 install_command = pip install --upgrade {opts} {packages}
 deps=
@@ -20,7 +23,7 @@ commands=
 install_command = pip install --upgrade {opts} {packages}
 deps=
   flake8
-commands=flake8 --select=F,E9 {posargs:*.py collectors tests}
+commands=flake8 --select=F,E9 {posargs:cephmetrics.py dashUpdater.py collectors tests}
 
 # Integration tests must operate against a live deployment. To run, simply:
 #   tox -e integration /path/to/inventory


### PR DESCRIPTION
The node-exporter disk-related metrics will sometimes use the db_device
label instead of the wal_device label.

Signed-off-by: Zack Cerza <zack@redhat.com>